### PR TITLE
Support Json.NET 10 SerializationBinder setting

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/Examples/SerializerSettingsDuplicator.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/SerializerSettingsDuplicator.cs
@@ -62,6 +62,9 @@ namespace Swashbuckle.AspNetCore.Filters
                 PreserveReferencesHandling = controllerSerializerSettings.PreserveReferencesHandling,
                 ReferenceLoopHandling = controllerSerializerSettings.ReferenceLoopHandling,
                 TypeNameHandling = controllerSerializerSettings.TypeNameHandling,
+#if !NETSTANDARD1_6
+                SerializationBinder = controllerSerializerSettings.SerializationBinder
+#endif
             };
         }
     }


### PR DESCRIPTION
Add support Json.NET 10 SerializationBinder setting to .NET 4.6.1/.NET Standard 2.0 target platforms