### PR TITLE
PreSerialize filter for filtering of swagger JSON per operation tags by query params

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/PreSerializeFilters/SwaggerPreSerializeFilters.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/PreSerializeFilters/SwaggerPreSerializeFilters.cs
@@ -19,7 +19,7 @@ namespace Swashbuckle.AspNetCore.Filters.PreSerializeFilters
         /// Usage:
         /// app.UseSwagger(x => {
         ///     ...;
-        ///     x.PreSerializeFilters.Add(SwaggerPreSerializeFilters.SwaggerDocument);
+        ///     x.PreSerializeFilters.Add((doc, req) => SwaggerPreSerializeFilters.OperationTagFilterByQueryParam(doc, req, "tags", ","));
         /// }
         /// </remarks>
         public static void OperationTagFilterByQueryParam(SwaggerDocument doc, HttpRequest req, string queryParamName, char separator)

--- a/src/Swashbuckle.AspNetCore.Filters/PreSerializeFilters/SwaggerPreSerializeFilters.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/PreSerializeFilters/SwaggerPreSerializeFilters.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Swashbuckle.AspNetCore.Swagger;
+
+namespace Swashbuckle.AspNetCore.Filters.PreSerializeFilters
+{
+    public static class SwaggerPreSerializeFilters
+    {
+        /// <summary>
+        /// Filters swagger document before serialization to JSON
+        /// </summary>
+        /// <param name="doc">Swagger document object</param>
+        /// <param name="req">Current http request</param>
+        /// <param name="queryParamName">Name of query param from which to take collection of tag value</param>
+        /// <param name="separator"></param>
+        /// <remarks>
+        /// Usage:
+        /// app.UseSwagger(x => {
+        ///     ...;
+        ///     x.PreSerializeFilters.Add(SwaggerPreSerializeFilters.SwaggerDocument);
+        /// }
+        /// </remarks>
+        public static void OperationTagFilterByQueryParam(SwaggerDocument doc, HttpRequest req, string queryParamName, char separator)
+        {
+            if (string.IsNullOrEmpty(queryParamName))
+            {
+                return;
+            }
+
+            var tags = GetQueryParamsByKey(req, queryParamName, separator);
+            if (tags.Length == 0)
+            {
+                return;
+            }
+
+            // get paths with tags
+            var filteredPaths = doc.Paths
+                .Where(path =>
+                {
+                    var operations = new Operation[] { path.Value.Options, path.Value.Patch, path.Value.Get, path.Value.Post, path.Value.Put, path.Value.Delete };
+                    foreach (var operation in operations)
+                    {
+                        if (operation.TryFindTags(tags))
+                        {
+                            return true;
+                        }
+                    }
+                    return false;
+                })
+                .ToDictionary(f => f.Key, f => f.Value);
+
+            doc.Paths = filteredPaths;
+            if (filteredPaths.Count == 0)
+            {
+                doc.Definitions = null;
+            }
+        }
+
+        private static string[] GetQueryParamsByKey(HttpRequest req, string key, char separator)
+        {
+            return req.Query[key].ToString().Split(separator);
+        }
+
+        private static bool TryFindTags(this Operation operation, IEnumerable<string> tags)
+        {
+            if (operation == null)
+            {
+                return false;
+            }
+
+            return operation.Tags.Any(tag => tags.Contains(tag, StringComparer.OrdinalIgnoreCase));
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Filters/Swashbuckle.AspNetCore.Filters.csproj
+++ b/src/Swashbuckle.AspNetCore.Filters/Swashbuckle.AspNetCore.Filters.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Scrutor" Version="3.0.1" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="3.0.0" Condition="'$(TargetFramework)' == 'netstandard1.6'" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="3.0.0" Condition="'$(TargetFramework)' == 'netstandard1.6'" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="4.*" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'"  />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="4.*" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="4.*" Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net461'" />
   </ItemGroup>  
 </Project>


### PR DESCRIPTION
### PreSerialize filter to be  filtering swagger document per operation tags

If you ever build large microservices and have multiple swaggers distributed throughout services, you may want to filter multiple swagger documents by tags.

For example both if several services serve single business domain, and concrete requirements are to aggregate swagger documents from mutiple services and show them to end user grouped as a single swagger, this filter becomes very usable.


I used this in 4 projects already. I send /swagger.json?tags=param1%2Cparam2 etc. and Swashbuckle returns me only those that have these respective tags.


Then I used a single aggregator service to create new swagger json (not connected to Swashbuckle or any other swagger generating library or service).
