### PR TITLE
Fix HTTP 500 on double Response code specifying 401 / 403 

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/SecurityRequirementsOperationFilter/SecurityRequirementsOperationFilterT.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/SecurityRequirementsOperationFilter/SecurityRequirementsOperationFilterT.cs
@@ -48,8 +48,15 @@ namespace Swashbuckle.AspNetCore.Filters
 
             if (includeUnauthorizedAndForbiddenResponses)
             {
-                operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
-                operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
+                if (!operation.Responses.ContainsKey("401"))
+                {
+                    operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+                }
+
+                if (!operation.Responses.ContainsKey("403"))
+                {
+                    operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
+                }
             }
 
             var policies = policySelector(actionAttributes) ?? Enumerable.Empty<string>();

--- a/test/Swashbuckle.AspNetCore.Filters.Test/SecurityRequirementsOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/SecurityRequirementsOperationFilterTests.cs
@@ -200,5 +200,37 @@ namespace Swashbuckle.AspNetCore.Filters.Test
             // Assert
             operation.Security.Count.ShouldBe(0);
         }
+
+        [Fact]
+        public void Appy_Authorize_Forbidden_Operation_Already_Added()
+        {
+            // Arrange
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("403", new OpenApiResponse { Description = "Forbidden" });
+
+            var filterContext = FilterContextFor(typeof(AuthController), nameof(AuthController.Customer));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            Assert.Equal(2, operation.Responses.Count);
+        }
+
+        [Fact]
+        public void Appy_Authorize_Unauthorized_Operation_Already_Added()
+        {
+            // Arrange
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("401", new OpenApiResponse { Description = "Unauthorized" });
+
+            var filterContext = FilterContextFor(typeof(AuthController), nameof(AuthController.Customer));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            Assert.Equal(2, operation.Responses.Count);
+        }
     }
 }

--- a/test/WebApi2.0-Swashbuckle5/Controllers/ValuesController.cs
+++ b/test/WebApi2.0-Swashbuckle5/Controllers/ValuesController.cs
@@ -30,6 +30,7 @@ namespace WebApi.Controllers
         [SwaggerResponse(500, type: null, description: "There was an unexpected error")]
         [SwaggerResponseExample(500, typeof(InternalServerResponseExample))]
         [Authorize("Customer")]
+        [ProducesResponseType(401)]
         public PersonResponse GetPerson(int personId)
         {
             var personResponse = new PersonResponse { Id = personId, FirstName = "Dave" };
@@ -41,6 +42,7 @@ namespace WebApi.Controllers
         /// </summary>
         /// <param name="personRequest"></param>
         /// <returns></returns>
+        /// <response code="401">You are not authorized to access this endpoint</response>
         [HttpPost]
         [Route("api/values/person")]
         [SwaggerResponse(200, type: typeof(PersonResponse), description: "Successfully found the person")]


### PR DESCRIPTION
Fix HTTP 500 Error when adding 401 / 403 Response codes either via attribute or comment

Add unit tests to test the fix.

Closes #101 