### PR TITLE
Response header attribute can take an array of statuses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,8 +403,9 @@ This will add the input box to *every* controller action.
 
 Specify one or more `[SwaggerResponseHeader]` attributes on your controller action, like so:
 ```csharp
-[SwaggerResponseHeader(HttpStatusCode.OK, "Location", "string", "Location of the newly created resource")]
-[SwaggerResponseHeader(HttpStatusCode.OK, "ETag", "string", "An ETag of the resource")]
+[SwaggerResponseHeader((int)HttpStatusCode.OK, "Location", "string", "Location of the newly created resource")]
+[SwaggerResponseHeader(200, "ETag", "string", "An ETag of the resource")]
+[SwaggerResponseHeader(new int[] { 200, 401, 403, 404 }, "CustomHeader", "string", "A custom header")]
 public IHttpActionResult GetPerson(PersonRequest personRequest)
 {
 ```

--- a/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/AddResponseHeadersFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/AddResponseHeadersFilter.cs
@@ -15,16 +15,19 @@ namespace Swashbuckle.AspNetCore.Filters
 
             foreach (var attr in actionAttributes)
             {
-                var response = operation.Responses.FirstOrDefault(x => x.Key == ((int)attr.StatusCode).ToString(CultureInfo.InvariantCulture)).Value;
-
-                if (response != null)
+                foreach (var statusCode in attr.StatusCodes)
                 {
-                    if (response.Headers == null)
-                    {
-                        response.Headers = new Dictionary<string, OpenApiHeader>();
-                    }
+                    var response = operation.Responses.FirstOrDefault(x => x.Key == (statusCode).ToString(CultureInfo.InvariantCulture)).Value;
 
-                    response.Headers.Add(attr.Name, new OpenApiHeader { Description = attr.Description, Schema = new OpenApiSchema { Type = attr.Type } });
+                    if (response != null)
+                    {
+                        if (response.Headers == null)
+                        {
+                            response.Headers = new Dictionary<string, OpenApiHeader>();
+                        }
+
+                        response.Headers.Add(attr.Name, new OpenApiHeader { Description = attr.Description, Schema = new OpenApiSchema { Type = attr.Type } });
+                    }
                 }
             }
         }

--- a/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/SwaggerResponseHeaderAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/SwaggerResponseHeaderAttribute.cs
@@ -7,13 +7,21 @@ namespace Swashbuckle.AspNetCore.Filters
     {
         public SwaggerResponseHeaderAttribute(int statusCode, string name, string type, string description)
         {
-            StatusCode = statusCode;
+            StatusCodes = new int[] { statusCode };
             Name = name;
             Type = type;
             Description = description;
         }
 
-        public int StatusCode { get; }
+        public SwaggerResponseHeaderAttribute(int[] statusCode, string name, string type, string description)
+        {
+            StatusCodes = statusCode;
+            Name = name;
+            Type = type;
+            Description = description;
+        }
+
+        public int[] StatusCodes { get; }
 
         public string Name { get; }
 

--- a/test/WebApi2.0-Swashbuckle5/Controllers/ValuesController.cs
+++ b/test/WebApi2.0-Swashbuckle5/Controllers/ValuesController.cs
@@ -52,8 +52,9 @@ namespace WebApi.Controllers
 
         [SwaggerRequestExample(typeof(PersonRequest), typeof(PersonRequestExample), jsonConverter: typeof(StringEnumConverter))]
 
-        [SwaggerResponseHeader(200, "Location", "string", "Location of the newly created resource")]
+        [SwaggerResponseHeader((int)HttpStatusCode.OK, "Location", "string", "Location of the newly created resource")]
         [SwaggerResponseHeader(200, "ETag", "string", "An ETag of the resource")]
+        [SwaggerResponseHeader(new int[] { 200, 401, 403, 404 }, "CustomHeader", "string", "A custom header")]
         [Authorize("Customer")]
         public PersonResponse PostPerson([FromBody]PersonRequest personRequest)
         {


### PR DESCRIPTION
A small change that allows you to apply response headers to a number of responses in one line. This makes for tidier code when adding multiple headers to multiple responses.

e.g. 

```csharp
[SwaggerResponseHeader(200, "CustomHeader1", "string", "Custom header")]
[SwaggerResponseHeader(200, "CustomHeader2", "string", "Custom header")]
[SwaggerResponseHeader(200, "CustomHeader3", "string", "Custom header")]
[SwaggerResponseHeader(400, "CustomHeader1", "string", "Custom header")]
[SwaggerResponseHeader(400, "CustomHeader2", "string", "Custom header")]
[SwaggerResponseHeader(400, "CustomHeader3", "string", "Custom header")]
[SwaggerResponseHeader(403, "CustomHeader1", "string", "Custom header")]
[SwaggerResponseHeader(403, "CustomHeader2", "string", "Custom header")]
[SwaggerResponseHeader(403, "CustomHeader3", "string", "Custom header")]
[SwaggerResponseHeader(404, "CustomHeader1", "string", "Custom header")]
[SwaggerResponseHeader(404, "CustomHeader2", "string", "Custom header")]
[SwaggerResponseHeader(404, "CustomHeader3", "string", "Custom header")]
```

becomes

```csharp
[SwaggerResponseHeader(new int[]{ 200, 400, 403, 404 }, "CustomHeader1", "string", "Custom header")]
[SwaggerResponseHeader(new int[]{ 200, 400, 403, 404 }, "CustomHeader2", "string", "Custom header")]
[SwaggerResponseHeader(new int[]{ 200, 400, 403, 404 }, "CustomHeader3", "string", "Custom header")]
```
