### PR TITLE
Added optional parameter to set the format in the header attribute.

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,10 +401,13 @@ This will add the input box to *every* controller action.
 
 ### How to use - Response headers
 
-Specify one or more `[SwaggerResponseHeader]` attributes on your controller action, like so:
+Specify one or more `[SwaggerResponseHeader]` attributes on your controller action. 
+You can specify the status code (int), header name (string), type (string), description (string) and format (string). 
+See the OpenAPI Specification spec for information on DataTypes: https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.0.md#dataTypes
 ```csharp
 [SwaggerResponseHeader(StatusCodes.Status200OK, "Location", "string", "Location of the newly created resource")]
 [SwaggerResponseHeader(200, "ETag", "string", "An ETag of the resource")]
+[SwaggerResponseHeader(429, "Retry-After", "integer", "Indicates how long to wait before making a new request.", "int32")]
 [SwaggerResponseHeader(new int[] { 200, 401, 403, 404 }, "CustomHeader", "string", "A custom header")]
 public IHttpActionResult GetPerson(PersonRequest personRequest)
 {

--- a/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/AddResponseHeadersFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/AddResponseHeadersFilter.cs
@@ -26,7 +26,7 @@ namespace Swashbuckle.AspNetCore.Filters
                             response.Headers = new Dictionary<string, OpenApiHeader>();
                         }
 
-                        response.Headers.Add(attr.Name, new OpenApiHeader { Description = attr.Description, Schema = new OpenApiSchema { Type = attr.Type } });
+                        response.Headers.Add(attr.Name, new OpenApiHeader { Description = attr.Description, Schema = new OpenApiSchema { Description = attr.Description, Type = attr.Type, Format = attr.Format } });
                     }
                 }
             }

--- a/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/SwaggerResponseHeaderAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/ResponseHeaders/SwaggerResponseHeaderAttribute.cs
@@ -5,20 +5,22 @@ namespace Swashbuckle.AspNetCore.Filters
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = true)]
     public class SwaggerResponseHeaderAttribute : Attribute
     {
-        public SwaggerResponseHeaderAttribute(int statusCode, string name, string type, string description)
+        public SwaggerResponseHeaderAttribute(int statusCode, string name, string type, string description, string format = "")
         {
             StatusCodes = new int[] { statusCode };
             Name = name;
             Type = type;
             Description = description;
+            Format = format;
         }
 
-        public SwaggerResponseHeaderAttribute(int[] statusCode, string name, string type, string description)
+        public SwaggerResponseHeaderAttribute(int[] statusCode, string name, string type, string description, string format = "")
         {
             StatusCodes = statusCode;
             Name = name;
             Type = type;
             Description = description;
+            Format = format;
         }
 
         public int[] StatusCodes { get; }
@@ -28,5 +30,7 @@ namespace Swashbuckle.AspNetCore.Filters
         public string Type { get; }
 
         public string Description { get; }
+
+        public string Format { get; }
     }
 }


### PR DESCRIPTION
Optional format parameter to set the type of data in the headers. Also add the description to the schema. This is to support the Response Headers components in the html [swagger code generators](https://github.com/swagger-api/swagger-codegen-generators/tree/master/src/main/java/io/swagger/codegen/v3/generators/html).

e.g:
![image](https://user-images.githubusercontent.com/25739804/61943850-43431080-af94-11e9-9349-b2d73da54008.png)

The `Date` header is a type of string but has a format of HTTP-date or the `Retry-After` header can have a format of int32 or a HTTP-Date

See https://swagger.io/specification/#dataTypeFormat for more information

