### PR TITLE
Fix an issue where ignoring obsolete properties forced examples to use PascalCase

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/Examples/SerializerSettingsDuplicator.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/SerializerSettingsDuplicator.cs
@@ -34,7 +34,16 @@ namespace Swashbuckle.AspNetCore.Filters
             }
             else if (schemaGeneratorOptions.IgnoreObsoleteProperties)
             {
-                serializerSettings.ContractResolver = new ExcludeObsoletePropertiesResolver();
+                var resolver = new ExcludeObsoletePropertiesResolver();
+
+                // Preserve the naming strategy, which might be camel case
+                var namingStrategy = (serializerSettings.ContractResolver as DefaultContractResolver)?.NamingStrategy;
+                if (namingStrategy != null)
+                {
+                    resolver.NamingStrategy = namingStrategy;
+                }
+                
+                serializerSettings.ContractResolver = resolver;
             }
 
             if (attributeJsonConverter != null)


### PR DESCRIPTION
I found a bug where ExcludeObsoletePropertiesResolver was not preserving the NamingStrategy from the default JSON contract resolver.  This caused examples to always use PascalCase instead of honoring the desire to use camelCase.