### PR TITLE
Support for multiple examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,24 +18,26 @@ This library contains a bunch of filters for [Swashbuckle.AspNetCore](https://gi
 
 - [Where to get it](#where-to-get-it)
 - [What's included](#whats-included)
-  - [Request example](#request-example) 
+  - [Request example](#request-example)
   - [Response example](#response-example)
   - [Security requirements filter](#security-requirements-filter)
   - [Add a request header](#add-a-request-header)
   - [Add a response header](#add-a-response-header)
   - [Add Authorization to Summary](#add-authorization-to-summary)
-- [Installation](#installation) 
+- [Installation](#installation)
 - [How to use](#how-to-use)
-  - [How to use - Request examples](#how-to-use---request-examples) 
+  - [How to use - Request examples](#how-to-use---request-examples)
     - [Automatic annotation](#automatic-annotation)
     - [Manual annotation](#manual-annotation)
-      [List Request examples](#list-request-examples)
+    - [List Request examples](#list-request-examples)
   - [How to use - Response examples](#how-to-use---response-examples)
     - [Automatic annotation](#automatic-annotation-1)
-    - [Manual annotation](#manual-annotation)
+    - [Manual annotation](#manual-annotation-1)
     - [Known issues](#known-issues)
+  - [How to use - Multiple examples](#how-to-use---multiple-examples)
   - [How to use - Security requirements filter](#how-to-use---security-requirements-filter)
   - [How to use - Request Header](#how-to-use---request-header)
+  - [How to use - Response headers](#how-to-use---response-headers)
   - [How to use - Authorization summary](#how-to-use---authorization-summary)
 - [Pascal case or Camel case?](#pascal-case-or-camel-case)
 - [Render Enums as strings](#render-enums-as-strings)
@@ -366,6 +368,56 @@ Example response for application/json mimetype of a Pet data type:
 #### Known issues
 - Request examples are not shown for querystring parameters (i.e. HTTP GET requests, or for querystring parameters for POST, PUT etc methods). Request examples will only be shown in request body.
 This is as per the OpenApi 3.0 spec.
+
+
+### How to use - Multiple examples
+
+Sometimes more than a single example are desirable for an API. In this case you can use `IMultipleExamplesProvider<T>` rather than `IExamplesProvider<T>` to return multiple examples. The example provider class is still located in the same way (automatic or manual annotation), but the `GetExamples()` call returns an enumerated list of examples along with their name and optional summary. To reduce boilerplate, it is recommended to use `yield return` for each example value. Every returned `SwaggerExample<T>` should have different value of `Name` property.
+
+```csharp
+public class DeliveryOptionsSearchModelExample : IMultipleExamplesProvider<DeliveryOptionsSearchModel>
+{
+    public IEnumerable<SwaggerExample<DeliveryOptionsSearchModel>> GetExamples()
+    {
+        // An example without a summary.
+        yield return SwaggerExample.Create(
+            "Great Britain",
+            new DeliveryOptionsSearchModel
+            {
+                Lang = "en-GB",
+                Currency = "GBP",
+                Address = new AddressModel
+                {
+                    Address1 = "1 Gwalior Road",
+                    Locality = "London",
+                    Country = "GB",
+                    PostalCode = "SW15 1NP"
+                }
+            }
+        );
+
+        // An example with a summary.
+        yield return SwaggerExample.Create(
+            "United States",
+            "A minor former colony of Great Britain",
+            new DeliveryOptionsSearchModel
+            {
+                Lang = "en-US",
+                Currency = "USD",
+                Address = new AddressModel
+                {
+                    Address1 = "123 Main Street",
+                    Locality = "New York",
+                    Country = "US",
+                    PostalCode = "10001"
+                }
+            },
+        );
+    }
+```
+
+Note that UIs may choose to display the summary in different ways; in ReDoc, for example, the summary (if present) replaces the name in the UI.
+
 
 ### How to use - Security requirements filter
 

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesConverter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesConverter.cs
@@ -1,0 +1,66 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OpenApi.Any;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.Filters.Extensions;
+
+namespace Swashbuckle.AspNetCore.Filters
+{
+    internal class ExamplesConverter
+    {
+        private readonly JsonFormatter jsonFormatter;
+        private readonly MvcOutputFormatter mvcOutputFormatter;
+        private readonly JsonSerializerSettings serializerSettings;
+
+        public ExamplesConverter(JsonFormatter jsonFormatter, MvcOutputFormatter mvcOutputFormatter, JsonSerializerSettings serializerSettings)
+        {
+            this.jsonFormatter = jsonFormatter;
+            this.mvcOutputFormatter = mvcOutputFormatter;
+            this.serializerSettings = serializerSettings;
+        }
+
+        public IOpenApiAny SerializeExampleXml(object exampleValue)
+        {
+            return new OpenApiString(exampleValue.XmlSerialize(mvcOutputFormatter));
+        }
+
+        public IOpenApiAny SerializeExampleJson(object exampleValue)
+        {
+            return new OpenApiRawString(jsonFormatter.FormatJson(exampleValue, serializerSettings));
+        }
+
+        private static IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionary(
+            IEnumerable<ISwaggerExample<object>> examples,
+            Func<object, IOpenApiAny> exampleConverter)
+        {
+            var groupedExamples = examples.GroupBy(
+                ex => ex.Name,
+                ex => new OpenApiExample
+                {
+                    Summary = ex.Summary,
+                    Value = exampleConverter(ex.Value)
+                });
+
+            // If names are duplicated, only the first one is taken
+            var examplesDict = groupedExamples.ToDictionary(
+                grouping => grouping.Key,
+                grouping => grouping.First());
+
+            return examplesDict;
+        }
+
+        public IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionaryXml(
+            IEnumerable<ISwaggerExample<object>> examples)
+        {
+            return ToOpenApiExamplesDictionary(examples, SerializeExampleXml);
+        }
+
+        public IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionaryJson(
+            IEnumerable<ISwaggerExample<object>> examples)
+        {
+            return ToOpenApiExamplesDictionary(examples, SerializeExampleJson);
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/IMultipleExamplesProvider.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/IMultipleExamplesProvider.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace Swashbuckle.AspNetCore.Filters
+{
+    public interface IMultipleExamplesProvider<T>
+    {
+        IEnumerable<SwaggerExample<T>> GetExamples();
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ISwaggerExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ISwaggerExample.cs
@@ -1,0 +1,28 @@
+namespace Swashbuckle.AspNetCore.Filters
+{
+    /// <summary>
+    /// A single example out of multiple.
+    /// </summary>
+    /// <remarks>
+    /// It's important that the interface is co-variant.  That allows instances
+    /// of the interface to be found with "x as ISwaggerExample{object}" instead
+    /// of having to go through reflection gymnastics.
+    /// </remarks>
+    public interface ISwaggerExample<out T>
+    {
+        /// <summary>
+        /// Name of the example.  Required.
+        /// </summary>
+        string Name { get; }
+
+        /// <summary>
+        /// Optional summary of the example.
+        /// </summary>
+        string Summary { get; }
+
+        /// <summary>
+        /// The example value.  Required.
+        /// </summary>
+        T Value { get; }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/SwaggerExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/SwaggerExample.cs
@@ -1,0 +1,55 @@
+namespace Swashbuckle.AspNetCore.Filters
+{
+    /// <summary>
+    /// A single example out of multiple.
+    /// </summary>
+    /// <typeparam name="T">Type that the example is for.</typeparam>
+    public class SwaggerExample<T> : ISwaggerExample<T>
+    {
+        /// <summary>
+        /// Name of the example.  Required.
+        /// </summary>
+        public string Name { get; set; }
+
+        /// <summary>
+        /// Optional summary of the example.
+        /// </summary>
+        public string Summary { get; set; }
+
+        /// <summary>
+        /// The example value.  Required.
+        /// </summary>
+        public T Value { get; set; }
+    }
+
+    /// <summary>
+    /// Helper class to reduce generic boilerplate
+    /// </summary>
+    public static class SwaggerExample
+    {
+        /// <summary>
+        /// Create an example for a type.
+        /// </summary>
+        /// <param name="name">Name of the example.</param>
+        /// <param name="value">Example value.</param>
+        /// <typeparam name="T">Type that the example is for.</typeparam>
+        /// <returns>An example for the type.</returns>
+        public static SwaggerExample<T> Create<T>(string name, T value)
+        {
+            return new SwaggerExample<T> {Name = name, Value = value};
+        }
+
+        /// <summary>
+        /// Create an example for a type.
+        /// </summary>
+        /// <param name="name">Name of the example.</param>
+        /// <param name="summary">Summary of the example.</param>
+        /// <param name="value">Example value.</param>
+        /// <typeparam name="T">Type that the example is for.</typeparam>
+        /// <returns>An example for the type.</returns>
+        public static SwaggerExample<T> Create<T>(string name, string summary, T value)
+        {
+            return new SwaggerExample<T> {Name = name, Summary = summary, Value = value};
+        }
+    }
+}

--- a/src/Swashbuckle.AspNetCore.Filters/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Extensions/ServiceCollectionExtensions.cs
@@ -17,6 +17,13 @@ namespace Swashbuckle.AspNetCore.Filters
                     .AsSelf()
                     .WithSingletonLifetime()
             );
+            services.Scan(scan => scan
+                .FromAssemblyOf<T>()
+                    .AddClasses(classes => classes.AssignableTo(typeof(IMultipleExamplesProvider<>)))
+                    .AsImplementedInterfaces()
+                    .AsSelf()
+                    .WithSingletonLifetime()
+            );
 
             return services;
         }

--- a/src/Swashbuckle.AspNetCore.Filters/Extensions/ServiceProviderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Extensions/ServiceProviderExtensions.cs
@@ -38,7 +38,12 @@ namespace Swashbuckle.AspNetCore.Filters.Extensions
             }
 
             var exampleProviderType = typeof(IExamplesProvider<>).MakeGenericType(type);
-            return GetExampleWithExamplesProviderType(serviceProvider, exampleProviderType);
+            var singleExample = GetExampleWithExamplesProviderType(serviceProvider, exampleProviderType);
+            if (singleExample != null)
+                return singleExample;
+            
+            var multipleExampleProviderType = typeof(IMultipleExamplesProvider<>).MakeGenericType(type);
+            return GetExampleWithExamplesProviderType(serviceProvider, multipleExampleProviderType);
         }
 
         private static object InvokeGetExamples(Type exampleProviderType, object exampleProviderObject)

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Extensions/ExampleAssertExtensions.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Extensions/ExampleAssertExtensions.cs
@@ -1,4 +1,9 @@
-﻿using Shouldly;
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+using Shouldly;
 using Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples;
 
 namespace Swashbuckle.AspNetCore.Filters.Test.Extensions
@@ -10,6 +15,46 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Extensions
             actualExample.Title.ShouldBe(expectedExample.Title);
             actualExample.FirstName.ShouldBe(expectedExample.FirstName);
             actualExample.Age.ShouldBe(expectedExample.Age);
+        }
+
+        public static void ShouldMatch(this PersonResponse actualExample, PersonResponse expectedExample)
+        {
+            actualExample.Id.ShouldBe(expectedExample.Id);
+            actualExample.Title.ShouldBe(expectedExample.Title);
+            actualExample.FirstName.ShouldBe(expectedExample.FirstName);
+            actualExample.LastName.ShouldBe(expectedExample.LastName);
+            actualExample.Age.ShouldBe(expectedExample.Age);
+            actualExample.Income.ShouldBe(expectedExample.Income);
+        }
+
+        public static void ShouldMatch<T>(this OpenApiExample actualExample, ISwaggerExample<T> expectedExample, Action<T,T> matcher)
+        {
+            actualExample.Summary.ShouldBe(expectedExample.Summary);
+            var actualRequestValueSerialized = actualExample.Value.ShouldBeAssignableTo<OpenApiRawString>();
+            var actualRequestValue = JsonConvert.DeserializeObject<T>(actualRequestValueSerialized.Value);
+            matcher(actualRequestValue, expectedExample.Value);
+        }
+
+        public static void ShouldAllMatch<T>(
+            this IDictionary<string, OpenApiExample> actualExamples,
+            IEnumerable<ISwaggerExample<T>> expectedExamples,
+            Action<T,T> matcher)
+        {
+            var expectedExamplesList = expectedExamples.ToList();
+
+            // All expected examples should be in dictionary of actual examples
+            foreach (var expectedExample in expectedExamplesList)
+            {
+                actualExamples.ShouldContainKey(expectedExample.Name);
+                var actualExample = actualExamples[expectedExample.Name];
+                actualExample.ShouldMatch(expectedExample, matcher);
+            }
+
+            // No other examples should occur in the dictionary of actual examples
+            foreach (var actualExampleKey in actualExamples.Keys)
+            {
+                expectedExamplesList.ShouldContain(expectedExample => expectedExample.Name == actualExampleKey);
+            }
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/PersonRequestMultipleExamples.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/PersonRequestMultipleExamples.cs
@@ -1,0 +1,52 @@
+using System.Collections.Generic;
+
+namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
+{
+    internal class PersonRequestMultipleExamples : IMultipleExamplesProvider<PersonRequest>
+    {
+        public IEnumerable<SwaggerExample<PersonRequest>> GetExamples()
+        {
+            yield return SwaggerExample.Create("Dave",
+                "Posts Dave",
+                new PersonRequest {FirstName = "Dave", Title = Title.Mr});
+            yield return SwaggerExample.Create("Angela",
+                "Let's add Angela",
+                new PersonRequest {FirstName = "Angela", Title = Title.Dr});
+            yield return SwaggerExample.Create("Diane",
+                "Diane is also fine to post",
+                new PersonRequest {FirstName = "Diane", Title = Title.Mrs, Age = 30});
+            yield return SwaggerExample.Create("Michael",
+                "And the last example",
+                new PersonRequest {FirstName = "Michael", Income = 321.7m});
+        }
+    }
+
+    internal class PersonRequestMultipleExamplesDuplicatedKeys : IMultipleExamplesProvider<PersonRequest>
+    {
+        public IEnumerable<SwaggerExample<PersonRequest>> GetExamples()
+        {
+            yield return SwaggerExample.Create("Dave",
+                "Posts Dave",
+                new PersonRequest {FirstName = "Dave", Title = Title.Mr});
+            yield return SwaggerExample.Create("Dave",
+                "Posts other Dave",
+                new PersonRequest {FirstName = "Dave", Title = Title.Dr});
+        }
+    }
+
+    internal class PersonRequestMultipleExamplesNull : IMultipleExamplesProvider<PersonRequest>
+    {
+        public IEnumerable<SwaggerExample<PersonRequest>> GetExamples()
+        {
+            return null;
+        }
+    }
+
+    internal class PersonRequestMultipleExamplesEmpty : IMultipleExamplesProvider<PersonRequest>
+    {
+        public IEnumerable<SwaggerExample<PersonRequest>> GetExamples()
+        {
+            return new List<SwaggerExample<PersonRequest>>();
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/PersonResponseMultipleExamples.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/PersonResponseMultipleExamples.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+
+namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
+{
+    internal class PersonResponseMultipleExamples : IMultipleExamplesProvider<PersonResponse>
+    {
+        public IEnumerable<SwaggerExample<PersonResponse>> GetExamples()
+        {
+            yield return SwaggerExample.Create("Dave",
+                "Posts Dave",
+                new PersonResponse {FirstName = "Dave", Title = Title.Mr});
+            yield return SwaggerExample.Create("Angela",
+                "Posts Angela",
+                new PersonResponse {FirstName = "Angela", Title = Title.Dr});
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeActions.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeActions.cs
@@ -19,6 +19,13 @@ namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes
         }
 
         [SwaggerResponse(200, type: typeof(PersonResponse))]
+        [SwaggerResponseExample(200, typeof(PersonResponseMultipleExamples))]
+        public IActionResult AnnotatedWithSwaggerResponseMultipleExamplesAttribute()
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerResponse(200, type: typeof(PersonResponse))]
         [SwaggerResponseExample(200, typeof(PersonResponseExample), typeof(DefaultContractResolver))]
         public IActionResult AnnotatedWithSwaggerResponseExampleAttributePascalCase()
         {
@@ -39,6 +46,12 @@ namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes
 
         [SwaggerRequestExample(typeof(PersonRequest), typeof(PersonRequestExample), jsonConverter: typeof(StringEnumConverter))]
         public IActionResult AnnotatedWithSwaggerRequestExampleAttribute(PersonRequest personRequest)
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerRequestExample(typeof(PersonRequest), typeof(PersonRequestMultipleExamples), jsonConverter: typeof(StringEnumConverter))]
+        public IActionResult AnnotatedWithSwaggerRequestMultipleExamplesAttribute(PersonRequest personRequest)
         {
             throw new NotImplementedException();
         }

--- a/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
+++ b/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
@@ -64,6 +64,24 @@ namespace WebApi.Controllers
         }
 
         /// <summary>
+        /// Posts a person. Multiple request body and response examples provided.
+        /// </summary>
+        /// <param name="personRequest"></param>
+        /// <returns></returns>
+        /// <response code="401">You are not authorized to access this endpoint</response>
+        [HttpPost]
+        [AllowAnonymous]
+        [Route("api/values/anyone")]
+        [SwaggerResponse(200, type: typeof(PersonResponse), description: "Successfully added the person")]
+        [SwaggerRequestExample(typeof(PersonRequest), typeof(PersonRequestMultipleExamples))]
+        [SwaggerResponseExample(200, typeof(PersonResponseMultipleExamples))]
+        public PersonResponse PostAnyone([FromBody]PersonRequest personRequest)
+        {
+            var personResponse = new PersonResponse { Id = 1, FirstName = "Dave", LastName = "Multi" };
+            return personResponse;
+        }
+
+        /// <summary>
         /// No [SwaggerRequestExample] or [SwaggerResponseExample] attributes on this one
         /// </summary>
         /// <param name="maleRequest"></param>

--- a/test/WebApi2.1-Swashbuckle5/Models/Examples/PersonRequestMultipleExamples.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/Examples/PersonRequestMultipleExamples.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace WebApi.Models.Examples
+{
+    public class PersonRequestMultipleExamples : IMultipleExamplesProvider<PersonRequest>
+    {
+        public IEnumerable<SwaggerExample<PersonRequest>> GetExamples()
+        {
+            yield return SwaggerExample.Create("Dave",
+                "Posts Dave",
+                new PersonRequest {FirstName = "Dave", Title = Title.Mr});
+            yield return SwaggerExample.Create("Angela",
+                "Let's add Angela",
+                new PersonRequest {FirstName = "Angela", Title = Title.Dr});
+            yield return SwaggerExample.Create("Diane",
+                "Diane is also fine to post",
+                new PersonRequest {FirstName = "Diane", Title = Title.Mrs, Age = 30});
+            yield return SwaggerExample.Create("Michael",
+                "And the last example",
+                new PersonRequest {FirstName = "Michael", Income = 321.7m});
+        }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/Models/Examples/PersonResponseMultipleExamples.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/Examples/PersonResponseMultipleExamples.cs
@@ -1,0 +1,24 @@
+﻿using System.Collections.Generic;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace WebApi.Models.Examples
+{
+    internal class PersonResponseMultipleExamples : IMultipleExamplesProvider<PersonResponse>
+    {
+        public IEnumerable<SwaggerExample<PersonResponse>> GetExamples()
+        {
+            yield return new SwaggerExample<PersonResponse>()
+            {
+                Name = "John",
+                Summary = "can return John",
+                Value = new PersonResponse {Id = 123, Title = Title.Dr, FirstName = "John", LastName = "Doe", Age = 27, Income = null}
+            };
+            yield return new SwaggerExample<PersonResponse>()
+            {
+                Name = "Angela",
+                Summary = "or Angela",
+                Value = new PersonResponse {Id = 124, Title = Title.Miss, FirstName = "Angela", LastName = "Doe", Age = 28, Income = null}
+            };
+        }
+    }
+}

--- a/test/WebApi3.0-Swashbuckle5/WebApi3.0-Swashbuckle5.csproj
+++ b/test/WebApi3.0-Swashbuckle5/WebApi3.0-Swashbuckle5.csproj
@@ -27,8 +27,10 @@
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonRequestDependencyInjectionExample.cs" Link="Models\Examples\PersonRequestDependencyInjectionExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonRequestExample.cs" Link="Models\Examples\PersonRequestExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonRequestExample2.cs" Link="Models\Examples\PersonRequestExample2.cs" />
+    <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonRequestMultipleExamples.cs" Link="Models\Examples\PersonRequestMultipleExamples.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonResponseAutoExample.cs" Link="Models\Examples\PersonResponseAutoExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonResponseExample.cs" Link="Models\Examples\PersonResponseExample.cs" />
+    <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonResponseMultipleExamples.cs" Link="Models\Examples\PersonResponseMultipleExamples.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonResponseExample2.cs" Link="Models\Examples\PersonResponseExample2.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\TitleExample.cs" Link="Models\Examples\TitleExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\WrappedPersonRequestExample.cs" Link="Models\Examples\WrappedPersonRequestExample.cs" />


### PR DESCRIPTION
Based on PR https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/pull/111 by @tomkludy

- Support for multiple examples in request body and responses (issue https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/issues/109)
- Unit tests
- Demo method in `ValueController`
- Common code in `RequestExample` and `ResponseExample` classes extracted to separate class `ExamplesConverter`