### PR TITLE
Add explicit Newtonsoft.Json dependency

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/Swashbuckle.AspNetCore.Filters.csproj
+++ b/src/Swashbuckle.AspNetCore.Filters/Swashbuckle.AspNetCore.Filters.csproj
@@ -31,6 +31,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.1.0" />
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Scrutor" Version="3.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />


### PR DESCRIPTION
This library makes direct use of Newtonsoft.Json...

https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/blob/400ed3f888a83fd70e86a28a32059a0945d623c5/src/Swashbuckle.AspNetCore.Filters/Examples/ExcludeObsoletePropertiesResolver.cs#L1-L8

...but that is not reflected in its direct NuGet dependencies...

https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/blob/400ed3f888a83fd70e86a28a32059a0945d623c5/src/Swashbuckle.AspNetCore.Filters/Swashbuckle.AspNetCore.Filters.csproj#L31-L37

...which usually doesn't cause a problem because Newtonsoft is usually pulled in transitively via Scrutor and an older version of Microsoft.Extensions.DependencyModel...

![image](https://user-images.githubusercontent.com/30168010/96081115-f9797980-0efb-11eb-8c17-e8e4c1e17942.png)

...but if an application ends up using a newer version of Microsoft.Extensions.DependencyModel which _doesn't_ use Newtonsoft...

![image](https://user-images.githubusercontent.com/30168010/96082533-b967c600-0efe-11eb-9466-7542b8edba45.png)

...then applications can end up without the necessary Newtonsoft.Json library.
