### PR TITLE
Dependency Cleanup

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/AppendAuthorizeToSummary/AppendAuthorizeToSummaryOperationFilterT.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/AppendAuthorizeToSummary/AppendAuthorizeToSummaryOperationFilterT.cs
@@ -16,8 +16,7 @@ namespace Swashbuckle.AspNetCore.Filters
         /// <summary>
         /// Constructor for AppendAuthorizeToSummaryOperationFilter
         /// </summary>
-        /// <param name="policySelectionCondition">Selects which attributes have policies. e.g. (a => !string.IsNullOrEmpty(a.Policy))</param>
-        /// <param name="policySelector">Used to select the authorization policy from the attribute e.g. (a => a.Policy)</param>
+        /// <param name="policySelectors">Used to select the authorization policy from the attribute e.g. (a => a.Policy)</param>
         public AppendAuthorizeToSummaryOperationFilter(IEnumerable<PolicySelectorWithLabel<T>> policySelectors)
         {
             this.policySelectors = policySelectors;

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/OpenApiRawString.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/OpenApiRawString.cs
@@ -7,7 +7,7 @@ namespace Swashbuckle.AspNetCore.Filters
     /// <summary>
     /// Represents a raw value that should not be encoded
     /// </summary>
-    internal class OpenApiRawString : IOpenApiAny, IOpenApiPrimitive
+    internal class OpenApiRawString : IOpenApiPrimitive
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="OpenApiRawString"/> class.

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/SwaggerRequestExampleAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/SwaggerRequestExampleAttribute.cs
@@ -16,8 +16,6 @@ namespace Swashbuckle.AspNetCore.Filters
         /// </summary>
         /// <param name="requestType">The type passed to the request</param>
         /// <param name="examplesProviderType">A type that inherits from IExamplesProvider</param>
-        /// <param name="contractResolver">An optional json contract Resolver if you want to override the one you use</param>
-        /// <param name="jsonConverter">An optional jsonConverter to use, e.g. typeof(StringEnumConverter) will render strings as enums</param>
         public SwaggerRequestExampleAttribute(Type requestType, Type examplesProviderType)
         {
             RequestType = requestType;

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/SwaggerResponseExampleAttribute.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/SwaggerResponseExampleAttribute.cs
@@ -16,8 +16,6 @@ namespace Swashbuckle.AspNetCore.Filters
         /// </summary>
         /// <param name="statusCode">The HTTP status code, e.g. 200</param>
         /// <param name="examplesProviderType">A type that inherits from IExamplesProvider</param>
-        /// <param name="contractResolver">An optional json contract Resolver if you want to override the one you use</param>
-        /// <param name="jsonConverter">An optional jsonConverter to use, e.g. typeof(StringEnumConverter) will render strings as enums</param>
         public SwaggerResponseExampleAttribute(int statusCode, Type examplesProviderType)
         {
             StatusCode = statusCode;

--- a/src/Swashbuckle.AspNetCore.Filters/Swashbuckle.AspNetCore.Filters.csproj
+++ b/src/Swashbuckle.AspNetCore.Filters/Swashbuckle.AspNetCore.Filters.csproj
@@ -31,8 +31,7 @@
     <PackageReference Include="Microsoft.OpenApi" Version="1.2.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Scrutor" Version="3.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.0.0" />
   </ItemGroup>
 
 </Project>

--- a/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
+++ b/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
@@ -3,7 +3,6 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.JsonPatch.Operations;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Converters;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 using System.Collections.Generic;

--- a/test/WebApi2.1-Swashbuckle5/Startup.cs
+++ b/test/WebApi2.1-Swashbuckle5/Startup.cs
@@ -2,7 +2,6 @@
 using System.IO;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;

--- a/test/WebApi2.1-Swashbuckle5/WebApi2.1-Swashbuckle5.csproj
+++ b/test/WebApi2.1-Swashbuckle5/WebApi2.1-Swashbuckle5.csproj
@@ -11,6 +11,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/WebApi3.0-Swashbuckle5/WebApi3.0-Swashbuckle5.csproj
+++ b/test/WebApi3.0-Swashbuckle5/WebApi3.0-Swashbuckle5.csproj
@@ -46,6 +46,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Matt,

I hoisted the SwaggerUI & Annotations dependencies up to your example projects in your test folder since those are the only places they are used.  This let's someone who is using ReDoc not have to download SwaggerUI if they consume your library.   Your filters only need with the SwaggerGen stuff which can be consumed by either UI.

Let me know if you need any changes.  Once this gets in I'll break the attributes and interfaces into the abstractions package I mentioned in [177](https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/issues/177)

Buvy