### PR TITLE
Inspect base classes for Authorize attribute

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/AppendAuthorizeToSummary/AppendAuthorizeToSummaryOperationFilterT.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/AppendAuthorizeToSummary/AppendAuthorizeToSummaryOperationFilterT.cs
@@ -29,7 +29,7 @@ namespace Swashbuckle.AspNetCore.Filters
                 return;
             }
 
-            var authorizeAttributes = context.GetControllerAndActionAttributes<T>();
+            var authorizeAttributes = context.GetControllerAndActionAttributes<T>(inherit: true);
 
             if (authorizeAttributes.Any())
             {

--- a/src/Swashbuckle.AspNetCore.Filters/Extensions/OperationFilterContextExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Extensions/OperationFilterContextExtensions.cs
@@ -7,10 +7,10 @@ namespace Swashbuckle.AspNetCore.Filters.Extensions
 {
     internal static class OperationFilterContextExtensions
     {
-        public static IEnumerable<T> GetControllerAndActionAttributes<T>(this OperationFilterContext context) where T : Attribute
+        public static IEnumerable<T> GetControllerAndActionAttributes<T>(this OperationFilterContext context, bool inherit = false) where T : Attribute
         {
-            var controllerAttributes = context.MethodInfo.DeclaringType.GetTypeInfo().GetCustomAttributes<T>();
-            var actionAttributes = context.MethodInfo.GetCustomAttributes<T>();
+            var controllerAttributes = context.MethodInfo.DeclaringType.GetTypeInfo().GetCustomAttributes<T>(inherit);
+            var actionAttributes = context.MethodInfo.GetCustomAttributes<T>(inherit);
 
             var result = new List<T>(controllerAttributes);
             result.AddRange(actionAttributes);

--- a/src/Swashbuckle.AspNetCore.Filters/SecurityRequirementsOperationFilter/SecurityRequirementsOperationFilterT.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/SecurityRequirementsOperationFilter/SecurityRequirementsOperationFilterT.cs
@@ -39,7 +39,7 @@ namespace Swashbuckle.AspNetCore.Filters
                 return;
             }
 
-            var actionAttributes = context.GetControllerAndActionAttributes<T>();
+            var actionAttributes = context.GetControllerAndActionAttributes<T>(inherit: true);
 
             if (!actionAttributes.Any())
             {


### PR DESCRIPTION
Applies to https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/issues/93

### Problem
When using "secure by default", authorisation is applied to all controllers automatically, and individual controllers and actions can be decorated with `[AllowAnonymous]` as needed. However the `SecurityRequirementsOperationFilter` cannot detect such a global filter.

### Solution
One can use a base class for all controllers, and apply `[Authorize]` to it (this is a workaround, as the global filter would still be in place).

My edits allow `SecurityRequirementsOperationFilter` to detect the attribute on the base class. That removes the need to decorate EVERY controller.

### Note
In the [original](https://github.com/mattfrear/Swashbuckle.AspNetCore.Filters/blob/6cdd5e854bc4dcc3c4700a8cc4a43f8b926e734b/src/Swashbuckle.AspNetCore.Filters/SecurityRequirementsOperationFilter/SecurityRequirementsOperationFilterT.cs#L13) code, it says that it is inspired by a method used in SwashBuckle itself. And if you look there you'll see that it too checks base classes for that attribute. So let's be inspired all the way, and do it too! :smile: