### PR TITLE
Adjusting Body/Response schemas to exactly match associated examples types

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/IMultipleExamplesProvider.cs
+++ b/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/IMultipleExamplesProvider.cs
@@ -2,6 +2,10 @@ using System.Collections.Generic;
 
 namespace Swashbuckle.AspNetCore.Filters
 {
+    public interface IMultipleExamplesProvider : IMultipleExamplesProvider<object>
+    {
+    }
+
     public interface IMultipleExamplesProvider<T>
     {
         IEnumerable<SwaggerExample<T>> GetExamples();

--- a/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/ISwaggerExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/ISwaggerExample.cs
@@ -8,8 +8,22 @@ namespace Swashbuckle.AspNetCore.Filters
     /// of the interface to be found with "x as ISwaggerExample{object}" instead
     /// of having to go through reflection gymnastics.
     /// </remarks>
-    public interface ISwaggerExample<out T>
+    public interface ISwaggerExample<out T> : ISwaggerExample
     {
+        /// <summary>
+        /// The example value.  Required.
+        /// </summary>
+        T Value { get; }
+    }
+
+    public interface ISwaggerExample
+    {
+        /// <summary>
+        /// Returns value assigned to SwaggerExample
+        /// </summary>
+        /// <returns></returns>
+        object GetValue();
+
         /// <summary>
         /// Name of the example.  Required.
         /// </summary>
@@ -19,10 +33,5 @@ namespace Swashbuckle.AspNetCore.Filters
         /// Optional summary of the example.
         /// </summary>
         string Summary { get; }
-
-        /// <summary>
-        /// The example value.  Required.
-        /// </summary>
-        T Value { get; }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/SwaggerExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/SwaggerExample.cs
@@ -25,7 +25,7 @@ namespace Swashbuckle.AspNetCore.Filters
     /// <summary>
     /// Helper class to reduce generic boilerplate
     /// </summary>
-    public static class SwaggerExample
+    public class SwaggerExample : SwaggerExample<object>
     {
         /// <summary>
         /// Create an example for a type.

--- a/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/SwaggerExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters.Abstractions/Examples/SwaggerExample.cs
@@ -7,6 +7,11 @@ namespace Swashbuckle.AspNetCore.Filters
     public class SwaggerExample<T> : ISwaggerExample<T>
     {
         /// <summary>
+        /// Returns value assigned to the Swagger Example
+        /// </summary>
+        public object GetValue() => Value;
+
+        /// <summary>
         /// Name of the example.  Required.
         /// </summary>
         public string Name { get; set; }

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesConverter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesConverter.cs
@@ -31,19 +31,19 @@ namespace Swashbuckle.AspNetCore.Filters
         }
 
         public IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionaryXml(
-            IEnumerable<ISwaggerExample<object>> examples)
+            IEnumerable<ISwaggerExample> examples)
         {
             return ToOpenApiExamplesDictionary(examples, SerializeExampleXml);
         }
 
         public IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionaryJson(
-            IEnumerable<ISwaggerExample<object>> examples)
+            IEnumerable<ISwaggerExample> examples)
         {
             return ToOpenApiExamplesDictionary(examples, SerializeExampleJson);
         }
 
         private static IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionary(
-            IEnumerable<ISwaggerExample<object>> examples,
+            IEnumerable<ISwaggerExample> examples,
             Func<object, IOpenApiAny> exampleConverter)
         {
             var groupedExamples = examples.GroupBy(
@@ -51,7 +51,7 @@ namespace Swashbuckle.AspNetCore.Filters
                 ex => new OpenApiExample
                 {
                     Summary = ex.Summary,
-                    Value = exampleConverter(ex.Value)
+                    Value = exampleConverter(ex.GetValue())
                 });
 
             // If names are duplicated, only the first one is taken

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesOperationFilter.cs
@@ -58,6 +58,7 @@ namespace Swashbuckle.AspNetCore.Filters
 
                 responseExample.SetResponseExampleForStatusCode(
                     operation,
+                    context.SchemaRepository,
                     attr.StatusCode,
                     example);
             }

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
@@ -45,7 +45,7 @@ namespace Swashbuckle.AspNetCore.Filters
             var examplesConverter = new ExamplesConverter(mvcOutputFormatter);
 
             IOpenApiAny firstOpenApiExample;
-            if (example is IEnumerable<ISwaggerExample<object>> multiple)
+            if (example is IEnumerable<ISwaggerExample> multiple)
             {
                 var multipleList = multiple.ToList();
                 firstOpenApiExample = SetMultipleRequestExamplesForOperation(operation, multipleList, examplesConverter);
@@ -80,13 +80,13 @@ namespace Swashbuckle.AspNetCore.Filters
         /// </summary>
         private void SetMultipleSchema(OpenApiOperation operation,
                 SchemaRepository schemaRepository,
-                List<ISwaggerExample<object>> examples)
+                List<ISwaggerExample> examples)
         {
-            var exampleTypes = examples.Where(x => x.Value != null).Select(x => x.Value?.GetType()).Distinct().ToList();
+            var exampleTypes = examples.Where(x => x.GetValue() != null).Select(x => x.GetValue()?.GetType()).Distinct().ToList();
 
             if (exampleTypes.Count == 1)
             {
-                SetSingleSchema(operation, schemaRepository, examples[0].Value);
+                SetSingleSchema(operation, schemaRepository, examples[0].GetValue());
                 return;
             }
 
@@ -158,7 +158,7 @@ namespace Swashbuckle.AspNetCore.Filters
         /// <returns>The first example so that it can be reused on the definition for V2</returns>
         private IOpenApiAny SetMultipleRequestExamplesForOperation(
             OpenApiOperation operation,
-            IEnumerable<ISwaggerExample<object>> examples,
+            IEnumerable<ISwaggerExample> examples,
             ExamplesConverter examplesConverter)
         {
             var jsonExamples = new Lazy<IDictionary<string, OpenApiExample>>(() =>

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
@@ -67,6 +67,18 @@ namespace Swashbuckle.AspNetCore.Filters
                     }
                 }
             }
+
+            // Use ISchemaGenerator to generate schemas
+            // schemaGenerator.GenerateSchema(typeof(ResponseExample), schemaRepository);
+            // schemaGenerator.GenerateSchema(typeof(ResponseExample), schemaRepository);
+            // schemaGenerator.GenerateSchema(typeof(ResponseExample), schemaRepository);
+
+            // Check if all types already exists as Schema in SchemaRepository
+            // If not - create missing schemas
+            // If only one example is provided and matches current schema don't change anything
+            // If only one example is provided and does not match schema, replace schema for current example
+            // If multiple examples provided of same type, set schema as Reference
+            // If multiple examples provided of different types, set Reference to null and fill OneOf schemas list
         }
 
         /// <summary>

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
@@ -76,7 +76,7 @@ namespace Swashbuckle.AspNetCore.Filters
 
                 var example = serviceProvider.GetExampleForType(response.Type);
 
-                responseExample.SetResponseExampleForStatusCode(operation, response.StatusCode, example);
+                responseExample.SetResponseExampleForStatusCode(operation, context.SchemaRepository, response.StatusCode, example);
             }
         }
     }

--- a/src/Swashbuckle.AspNetCore.Filters/Extensions/ServiceProviderExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Extensions/ServiceProviderExtensions.cs
@@ -32,9 +32,11 @@ namespace Swashbuckle.AspNetCore.Filters.Extensions
 
             bool IsPrimitiveType()
             {
-                return !type.GetTypeInfo().IsClass
-                    && !type.GetTypeInfo().IsGenericType
-                    && !type.GetTypeInfo().IsInterface;
+                var typeInfo = type.GetTypeInfo();
+                return !typeInfo.IsClass
+                    && !typeInfo.IsGenericType
+                    && !typeInfo.IsInterface
+                    && !typeInfo.IsEnum;
             }
 
             var exampleProviderType = typeof(IExamplesProvider<>).MakeGenericType(type);

--- a/test/Swashbuckle.AspNetCore.Filters.Test/BaseOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/BaseOperationFilterTests.cs
@@ -49,23 +49,21 @@ namespace Swashbuckle.AspNetCore.Filters.Test
             {
                 ContractResolver = contractResolver
             };
-            
+
             var schemaOptions = new SchemaGeneratorOptions();
 
             var schemaRepository = new SchemaRepository();
+            var schemaGenerator = new NewtonsoftSchemaGenerator(schemaOptions, jsonSerializerSettings);
 
             var methodInfo = controllerType.GetMethod(actionName);
             foreach (var parameterInfo in methodInfo.GetParameters())
             {
-                schemaRepository.GetOrAdd(parameterInfo.ParameterType, parameterInfo.ParameterType.SchemaDefinitionName(), () => new OpenApiSchema()
-                {
-                    Reference = new OpenApiReference { Id = parameterInfo.Name }
-                });
+                schemaGenerator.GenerateSchema(parameterInfo.ParameterType, schemaRepository); // Let's generate schema by generator, it's not always simple "Reference" schema
             }
 
             return new OperationFilterContext(
                 apiDescription,
-                new NewtonsoftSchemaGenerator(schemaOptions, jsonSerializerSettings),
+                schemaGenerator,
                 schemaRepository,
                 (apiDescription.ActionDescriptor as ControllerActionDescriptor).MethodInfo);
         }

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ExamplesOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ExamplesOperationFilterTests.cs
@@ -13,6 +13,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Swashbuckle.AspNetCore.Newtonsoft;
 using Xunit;
 
 namespace Swashbuckle.AspNetCore.Filters.Test.Examples
@@ -35,7 +36,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
             serviceProvider.GetService(typeof(DictionaryRequestExample)).Returns(new DictionaryRequestExample());
 
             var mvcOutputFormatter = new MvcOutputFormatter(FormatterOptions.WithXmlAndNewtonsoftJsonFormatters, new FakeLoggerFactory());
-            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions));
+            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions), new FakeNewtonsoftSchemaGenerator());
             var responseExample = new ResponseExample(mvcOutputFormatter);
 
             sut = new ExamplesOperationFilter(serviceProvider, requestExample, responseExample);
@@ -93,7 +94,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
             .AddNewtonsoftJson(opt =>
             {
                 opt.SerializerSettings.ContractResolver = new DefaultContractResolver();
-        
+
         public void SetsResponseExamples_FromMethodAttributesPascalCase()
         {
             // Arrange

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ExamplesOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ExamplesOperationFilterTests.cs
@@ -13,6 +13,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Swashbuckle.AspNetCore.Filters.Extensions;
 using Swashbuckle.AspNetCore.Newtonsoft;
 using Xunit;
 
@@ -33,11 +34,14 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
             serviceProvider.GetService(typeof(PersonResponseMultipleExamples)).Returns(new PersonResponseMultipleExamples());
             serviceProvider.GetService(typeof(PersonRequestExample)).Returns(new PersonRequestExample());
             serviceProvider.GetService(typeof(PersonRequestMultipleExamples)).Returns(new PersonRequestMultipleExamples());
+            serviceProvider.GetService(typeof(MultipleTypesRequestExamples)).Returns(new MultipleTypesRequestExamples());
+            serviceProvider.GetService(typeof(MultipleTypesResponseExamples)).Returns(new MultipleTypesResponseExamples());
             serviceProvider.GetService(typeof(DictionaryRequestExample)).Returns(new DictionaryRequestExample());
 
+            var schemaGenerator = new FakeNewtonsoftSchemaGenerator();
             var mvcOutputFormatter = new MvcOutputFormatter(FormatterOptions.WithXmlAndNewtonsoftJsonFormatters, new FakeLoggerFactory());
-            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions), new FakeNewtonsoftSchemaGenerator());
-            var responseExample = new ResponseExample(mvcOutputFormatter);
+            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions), schemaGenerator);
+            var responseExample = new ResponseExample(mvcOutputFormatter, schemaGenerator);
 
             sut = new ExamplesOperationFilter(serviceProvider, requestExample, responseExample);
         }
@@ -158,6 +162,272 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
             // Assert SerializeAsV2
             var actualSchemaExample = JsonConvert.DeserializeObject<PersonRequest>(((OpenApiRawString)filterContext.SchemaRepository.Schemas["PersonRequest"].Example).Value);
             actualSchemaExample.ShouldMatch(expectedExample);
+        }
+
+        [Fact]
+        public void GeneratesNewSchemaInSchemaRepository_FromMethodAttributes_WhenExpectedRequestSchemaDidNotExist()
+        {
+            // Arrange
+            var requestBody = new OpenApiRequestBody
+            {
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    { "application/json", new OpenApiMediaType() }
+                }
+            };
+
+            var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestExampleNotMatchingBodyType));
+
+            var expDefinitionName = new PersonRequestExample().GetExamples().GetType().SchemaDefinitionName();
+
+            // Act
+            filterContext.SchemaRepository.Schemas.ShouldNotContain(x => x.Key == expDefinitionName);
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            filterContext.SchemaRepository.Schemas.ShouldContain(x => x.Key == expDefinitionName);
+        }
+
+        [Fact]
+        public void SetsRequestCorrectSingleSchema_FromMethodAttributes_WhenExampleNotMatchBodyType()
+        {
+            // Arrange
+            var requestBody = new OpenApiRequestBody
+            {
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    { "application/json", new OpenApiMediaType() }
+                }
+            };
+
+            var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestExampleNotMatchingBodyType));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            var actualSchemaDefinition = requestBody.Content["application/json"].Schema.Reference.Id;
+            var expectedSchemaDefinition = new PersonRequestExample().GetExamples().GetType().SchemaDefinitionName();
+            actualSchemaDefinition.ShouldMatch(expectedSchemaDefinition);
+        }
+
+        [Fact]
+        public void GeneratesNewSchemasInSchemaRepository_FromMethodAttributes_WhenExpectedSchemasDidNotExist()
+        {
+            // Arrange
+            var requestBody = new OpenApiRequestBody
+            {
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    { "application/json", new OpenApiMediaType() }
+                }
+            };
+
+            var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestMultipleExamplesNotMatchingResponseAndBodyType));
+
+            // Act
+            var expSchemas = new MultipleTypesRequestExamples().GetExamples().Select(x => x.Value.GetType().SchemaDefinitionName()).Distinct().ToList();
+            filterContext.SchemaRepository.Schemas.Select(x => x.Key).ShouldNotContain(x => expSchemas.Contains(x));
+
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            expSchemas.ShouldBeSubsetOf(filterContext.SchemaRepository.Schemas.Select(x => x.Key));
+        }
+
+        [Fact]
+        public void SetsRequestCorrectMultipleRequestSchema_FromMethodAttributes_WhenMultipleExamplesAreOfDifferentTypes()
+        {
+            // Arrange
+            var requestBody = new OpenApiRequestBody
+            {
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    { "application/json", new OpenApiMediaType() }
+                }
+            };
+
+            var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestMultipleExamplesNotMatchingResponseAndBodyType));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            requestBody.Content["application/json"].Schema.Reference.ShouldBeNull();
+            requestBody.Content["application/json"].Schema.OneOf.Select(x => x.Reference.Id).ShouldBe(
+                new MultipleTypesRequestExamples().GetExamples().Select(x => x.Value.GetType().SchemaDefinitionName()).Distinct()
+            );
+        }
+
+        [Fact]
+        public void DoesNotGenerateAdditionalRequestSchema_FromMethodAttributes_WhenSchemaAlreadyExists()
+        {
+            // Arrange
+            var requestBody = new OpenApiRequestBody
+            {
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    { "application/json", new OpenApiMediaType() }
+                }
+            };
+
+            var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerRequestExampleAttribute));
+
+            // Act
+            filterContext.SchemaRepository.Schemas.Select(x => x.Key)
+                    .Count(x => x == typeof(PersonRequest).SchemaDefinitionName()).ShouldBe(1);
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            filterContext.SchemaRepository.Schemas.Select(x => x.Key)
+                    .Count(x => x == typeof(PersonRequest).SchemaDefinitionName()).ShouldBe(1);
+        }
+
+        [Fact]
+        public void SetsSingleRequestSchemaCorrectly_FromMethodAttributes_WhenMultipleExamplesAreOfSameType()
+        {
+            // Arrange
+            var requestBody = new OpenApiRequestBody
+            {
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    { "application/json", new OpenApiMediaType() }
+                }
+            };
+
+            var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerRequestMultipleExamplesAttribute));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            requestBody.Content["application/json"].Schema.Reference.Id.ShouldBe(typeof(PersonRequest).SchemaDefinitionName());
+        }
+
+
+        [Fact]
+        public void GeneratesNewSchemaInSchemaRepository_FromMethodAttributes_WhenExpectedResponseSchemaDidNotExist()
+        {
+            // Arrange
+            var response = new OpenApiResponse { Content = new Dictionary<string, OpenApiMediaType> { { "application/json", new OpenApiMediaType() } } };
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("200", response);
+
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestExampleNotMatchingBodyType));
+            var expDefinitionName = new PersonResponseExample().GetExamples().GetType().SchemaDefinitionName();
+
+            // Act
+            filterContext.SchemaRepository.Schemas.ShouldNotContain(x => x.Key == expDefinitionName);
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            filterContext.SchemaRepository.Schemas.ShouldContain(x => x.Key == expDefinitionName);
+        }
+
+        [Fact]
+        public void SetsResponseCorrectSingleSchema_FromMethodAttributes_WhenExampleDiffersFromDeclaredType()
+        {
+            // Arrange
+            var response = new OpenApiResponse { Content = new Dictionary<string, OpenApiMediaType> { { "application/json", new OpenApiMediaType()} } };
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("200", response);
+
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestExampleNotMatchingBodyType));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            var actualSchemaDefinition = operation.Responses["200"].Content["application/json"].Schema.Reference.Id;
+            var expectedSchemaDefinition = new PersonResponseExample().GetExamples().GetType().SchemaDefinitionName();
+            actualSchemaDefinition.ShouldMatch(expectedSchemaDefinition);
+        }
+
+        [Fact]
+        public void GeneratesNewSchemasInSchemaRepository_FromMethodAttributes_WhenExpectedResponseSchemasDidNotExist()
+        {
+            // Arrange
+            var response = new OpenApiResponse { Content = new Dictionary<string, OpenApiMediaType> { { "application/json", new OpenApiMediaType()} } };
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("200", response);
+
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestMultipleExamplesNotMatchingResponseAndBodyType));
+
+            // Act
+            var expSchemas = new MultipleTypesResponseExamples().GetExamples().Select(x => x.Value.GetType().SchemaDefinitionName()).Distinct().ToList();
+            filterContext.SchemaRepository.Schemas.Select(x => x.Key).ShouldNotContain(x => expSchemas.Contains(x));
+
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            expSchemas.ShouldBeSubsetOf(filterContext.SchemaRepository.Schemas.Select(x => x.Key));
+        }
+
+        [Fact]
+        public void SetsRequestCorrectMultipleResponseSchema_FromMethodAttributes_WhenMultipleExamplesAreOfDifferentTypes()
+        {
+            // Arrange
+            var response = new OpenApiResponse { Content = new Dictionary<string, OpenApiMediaType> { { "application/json", new OpenApiMediaType()} } };
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("200", response);
+
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseAndRequestMultipleExamplesNotMatchingResponseAndBodyType));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            operation.Responses["200"].Content["application/json"].Schema.Reference.ShouldBeNull();
+            operation.Responses["200"].Content["application/json"].Schema.OneOf.Select(x => x.Reference.Id).ShouldBe(
+                new MultipleTypesResponseExamples().GetExamples().Select(x => x.Value.GetType().SchemaDefinitionName()).Distinct()
+            );
+        }
+
+        [Fact]
+        public void DoesNotGenerateAdditionalResponseSchema_FromMethodAttributes_WhenSchemaAlreadyExists()
+        {
+            // Arrange
+            var response = new OpenApiResponse { Content = new Dictionary<string, OpenApiMediaType> { { "application/json", new OpenApiMediaType()} } };
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("200", response);
+
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseMultipleExamplesAttribute));
+
+            // Act
+            filterContext.SchemaRepository.Schemas.Select(x => x.Key)
+                    .Count(x => x == typeof(PersonResponse).SchemaDefinitionName()).ShouldBe(0);
+
+            for (var i = 0; i < 2; i++)
+            {
+                sut.Apply(operation, filterContext);
+
+                // Assert
+                filterContext.SchemaRepository.Schemas.Select(x => x.Key)
+                        .Count(x => x == typeof(PersonResponse).SchemaDefinitionName()).ShouldBe(1);
+            }
+        }
+
+        [Fact]
+        public void SetsSingleResponseSchemaCorrectly_FromMethodAttributes_WhenMultipleExamplesAreOfSameType()
+        {
+            // Arrange
+            var response = new OpenApiResponse { Content = new Dictionary<string, OpenApiMediaType> { { "application/json", new OpenApiMediaType()} } };
+            var operation = new OpenApiOperation { OperationId = "foobar", Responses = new OpenApiResponses() };
+            operation.Responses.Add("200", response);
+
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.AnnotatedWithSwaggerResponseMultipleExamplesAttribute));
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            operation.Responses["200"].Content["application/json"].Schema.Reference.Id.ShouldBe(typeof(PersonResponse).SchemaDefinitionName());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
@@ -30,7 +30,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
 
             var mvcOutputFormatter = new MvcOutputFormatter(FormatterOptions.WithXmlAndNewtonsoftJsonFormatters, new FakeLoggerFactory());
 
-            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions));
+            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions), new FakeNewtonsoftSchemaGenerator());
             var responseExample = new ResponseExample(mvcOutputFormatter);
 
             serviceProvider = Substitute.For<IServiceProvider>();

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
@@ -30,8 +30,9 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
 
             var mvcOutputFormatter = new MvcOutputFormatter(FormatterOptions.WithXmlAndNewtonsoftJsonFormatters, new FakeLoggerFactory());
 
-            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions), new FakeNewtonsoftSchemaGenerator());
-            var responseExample = new ResponseExample(mvcOutputFormatter);
+            var schemaGenerator = new FakeNewtonsoftSchemaGenerator();
+            var requestExample = new RequestExample(mvcOutputFormatter, Options.Create(swaggerOptions), schemaGenerator);
+            var responseExample = new ResponseExample(mvcOutputFormatter, schemaGenerator);
 
             serviceProvider = Substitute.For<IServiceProvider>();
             serviceProvider.GetService(typeof(IExamplesProvider<PersonResponse>)).Returns(new PersonResponseAutoExample());
@@ -451,7 +452,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
         {
             // Arrange
             var mvcOutputFormatter = new MvcOutputFormatter(FormatterOptions.WithSystemTextJsonFormatter, new FakeLoggerFactory());
-            var responseExample = new ResponseExample(mvcOutputFormatter);
+            var responseExample = new ResponseExample(mvcOutputFormatter, new FakeNewtonsoftSchemaGenerator());
             var sut = new ServiceProviderExamplesOperationFilter(serviceProvider, null, responseExample);
 
             var response = new OpenApiResponse { Content = new Dictionary<string, OpenApiMediaType> { { "application/json", new OpenApiMediaType() } } };

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
@@ -13,6 +13,7 @@ using Swashbuckle.AspNetCore.SwaggerGen;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using Swashbuckle.AspNetCore.Filters.Extensions;
 using Xunit;
 
 namespace Swashbuckle.AspNetCore.Filters.Test.Examples
@@ -271,6 +272,37 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
             // Assert SerializeAsV2
             var actualSchemaExample = JsonConvert.DeserializeObject<Title>(((OpenApiRawString)filterContext.SchemaRepository.Schemas["Title"].Example).Value);
             actualSchemaExample.ShouldBe(expectedExample);
+        }
+
+        /// <summary>
+        /// This test proves that fixed FilterContextFor should use SchemaGenerator instead of
+        /// arranging schema on your own hand
+        /// </summary>
+        [Fact]
+        public void WhenTypeIsNullable_SchemaGeneratorReservesIdForItsUnderlyingType()
+        {
+            // Pre-Arrange Assert
+            var schemaRepository = new SchemaRepository();
+
+            schemaRepository.TryGetIdFor(typeof(Title?), out var schemaId);
+            schemaId.ShouldBeNull();
+
+            schemaRepository.TryGetIdFor(typeof(Title), out schemaId);
+            schemaId.ShouldBeNull();
+
+            // Arrange
+            var schemaGenerator = new FakeNewtonsoftSchemaGenerator();
+
+            // Act
+            schemaGenerator.GenerateSchema(typeof(Title?), schemaRepository);
+
+            // Assert
+            schemaRepository.TryGetIdFor(typeof(Title?), out schemaId);
+            schemaId.ShouldBeNull();
+
+            schemaRepository.TryGetIdFor(typeof(Title), out schemaId);
+            schemaId.ShouldBe(typeof(Title).SchemaDefinitionName());
+            schemaId.ShouldBe(typeof(Title?).SchemaDefinitionName());
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterWithXmlDataContractTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterWithXmlDataContractTests.cs
@@ -25,10 +25,11 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
 
             var mvcOutputFormatter = new MvcOutputFormatter(FormatterOptions.WithXmlDataContractFormatter, new FakeLoggerFactory());
 
+            var schemaGenerator = new FakeNewtonsoftSchemaGenerator();
             sut = new ServiceProviderExamplesOperationFilter(
                 serviceProvider,
-                new RequestExample(mvcOutputFormatter, Options.Create(new Swagger.SwaggerOptions()), new FakeNewtonsoftSchemaGenerator()),
-                new ResponseExample(mvcOutputFormatter));
+                new RequestExample(mvcOutputFormatter, Options.Create(new Swagger.SwaggerOptions()), schemaGenerator),
+                new ResponseExample(mvcOutputFormatter, schemaGenerator));
         }
 
         [Fact]

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterWithXmlDataContractTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterWithXmlDataContractTests.cs
@@ -27,7 +27,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
 
             sut = new ServiceProviderExamplesOperationFilter(
                 serviceProvider,
-                new RequestExample(mvcOutputFormatter, Options.Create(new Swagger.SwaggerOptions())),
+                new RequestExample(mvcOutputFormatter, Options.Create(new Swagger.SwaggerOptions()), new FakeNewtonsoftSchemaGenerator()),
                 new ResponseExample(mvcOutputFormatter));
         }
 

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/TypeExtensionsTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/TypeExtensionsTests.cs
@@ -16,7 +16,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
         public void SchemaDefinitionName_ShouldCalculate(Type type, string expectedName)
         {
             // Arrange
-            var sut = new RequestExample(null, null);
+            var sut = new RequestExample(null, null, null);
 
             // Act
             var result = type.SchemaDefinitionName();

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Extensions/ExampleAssertExtensions.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Extensions/ExampleAssertExtensions.cs
@@ -10,6 +10,11 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Extensions
 {
     public static class ExampleAssertExtensions
     {
+        public static void ShouldMatch(this Title actualExample, Title expectedExample)
+        {
+            actualExample.ShouldBe(expectedExample);
+        }
+
         public static void ShouldMatch(this PersonRequest actualExample, PersonRequest expectedExample)
         {
             actualExample.Title.ShouldBe(expectedExample.Title);

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/AnimalRequest.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/AnimalRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
+{
+    public class AnimalRequest
+    {
+        public string Name { get; set; }
+        public string Race { get; set; }
+        public bool IsNeutered { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/AnimalResponse.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/AnimalResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
+{
+    public class AnimalResponse
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Race { get; set; }
+        public bool IsNeutered { get; set; }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/MultipleTypesRequestExamples.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/MultipleTypesRequestExamples.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
+{
+    public class MultipleTypesRequestExamples : IMultipleExamplesProvider
+    {
+        public IEnumerable<SwaggerExample<object>> GetExamples()
+        {
+            yield return new SwaggerExample
+            {
+                Name = "Animal",
+                Summary = "Posts Animal",
+                Value = new AnimalRequest
+                {
+                    Name = "Milo",
+                    Race = "Husky",
+                    IsNeutered = true
+                }
+            };
+
+            yield return new SwaggerExample
+            {
+                Name = "Human",
+                Summary = "Posts Person",
+                Value = new PersonRequest
+                {
+                    FirstName = "Anthony",
+                    Age = 25,
+                    Title = Title.Dr,
+                    Income = 4220.58M
+                }
+            };
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/MultipleTypesResponseExamples.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/MultipleTypesResponseExamples.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+
+namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
+{
+    public class MultipleTypesResponseExamples : IMultipleExamplesProvider
+    {
+        public IEnumerable<SwaggerExample<object>> GetExamples()
+        {
+            yield return new SwaggerExample
+            {
+                Name = "Animal",
+                Summary = "Lovely dog",
+                Value = new AnimalResponse
+                {
+                    Id = 29,
+                    Name = "Milo",
+                    Race = "Husky",
+                    IsNeutered = true
+                }
+            };
+
+            yield return new SwaggerExample
+            {
+                Name = "Human",
+                Summary = "Humble person",
+                Value = new PersonResponse
+                {
+                    Id = 78,
+                    FirstName = "Anthony",
+                    LastName = "Brown",
+                    Age = 25,
+                    Title = Title.Dr,
+                    Income = 4220.58M,
+                }
+            };
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/TitleMultipleExamplesProvider.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/TitleMultipleExamplesProvider.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
+{
+    public class TitleMultipleExamplesProvider : IMultipleExamplesProvider<Title>
+    {
+        public IEnumerable<SwaggerExample<Title>> GetExamples()
+        {
+            yield return new SwaggerExample<Title>
+            {
+                Name = "Miss Title",
+                Value = Title.Miss
+            };
+
+            yield return new SwaggerExample<Title>
+            {
+                Name = "Mr Title",
+                Value = Title.Mr
+            };
+        }
+    }
+}

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeActions.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeActions.cs
@@ -85,6 +85,12 @@ namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes
             throw new NotImplementedException();
         }
 
+        [SwaggerRequestExample(typeof(Title), typeof(TitleMultipleExamplesProvider))]
+        public IActionResult AnnotatedWithEnumMultipleExamples(Title personRequest)
+        {
+            throw new NotImplementedException();
+        }
+
         public IActionResult DictionaryRequestAttribute(Dictionary<string, object> personRequest)
         {
             throw new NotImplementedException();

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeActions.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeActions.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
-using Newtonsoft.Json.Converters;
-using Newtonsoft.Json.Serialization;
 using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples;
 
@@ -14,6 +12,22 @@ namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes
         [SwaggerResponse(200, type: typeof(PersonResponse))]
         [SwaggerResponseExample(200, typeof(PersonResponseExample))]
         public IActionResult AnnotatedWithSwaggerResponseExampleAttribute()
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerResponse(200, type: typeof(object))]
+        [SwaggerRequestExample(typeof(object), typeof(MultipleTypesRequestExamples))]
+        [SwaggerResponseExample(200, typeof(MultipleTypesResponseExamples))]
+        public IActionResult AnnotatedWithSwaggerResponseAndRequestMultipleExamplesNotMatchingResponseAndBodyType([FromBody] object body)
+        {
+            throw new NotImplementedException();
+        }
+
+        [SwaggerResponse(200, type: typeof(object))]
+        [SwaggerRequestExample(typeof(object), typeof(PersonRequestExample))]
+        [SwaggerResponseExample(200, typeof(PersonResponseExample))]
+        public IActionResult AnnotatedWithSwaggerResponseAndRequestExampleNotMatchingBodyType([FromBody] object ops)
         {
             throw new NotImplementedException();
         }

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeNewtonsoftSchemaGenerator.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Fakes/FakeNewtonsoftSchemaGenerator.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Swashbuckle.AspNetCore.Newtonsoft;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes
+{
+    public class FakeNewtonsoftSchemaGenerator : NewtonsoftSchemaGenerator
+    {
+        public FakeNewtonsoftSchemaGenerator() : base(new SchemaGeneratorOptions(), new JsonSerializerSettings
+        {
+            ContractResolver = new CamelCasePropertyNamesContractResolver()
+        })
+        { }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
+++ b/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
@@ -232,4 +232,9 @@ namespace WebApi.Controllers
         {
         }
     }
+
+    public enum Test
+    {
+
+    }
 }

--- a/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
+++ b/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Authorization;
+﻿using System;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.JsonPatch;
 using Microsoft.AspNetCore.JsonPatch.Operations;
@@ -7,6 +8,7 @@ using Swashbuckle.AspNetCore.Annotations;
 using Swashbuckle.AspNetCore.Filters;
 using System.Collections.Generic;
 using System.Net;
+using Newtonsoft.Json;
 using WebApi.Models;
 using WebApi.Models.Examples;
 
@@ -49,9 +51,7 @@ namespace WebApi.Controllers
         [SwaggerResponseExample(200, typeof(PersonResponseExample))]
         [SwaggerResponse(500, type: null, description: "There was an unexpected error")]
         [SwaggerResponseExample(500, typeof(InternalServerResponseExample))]
-
         [SwaggerRequestExample(typeof(PersonRequest), typeof(PersonRequestExample))]
-
         [SwaggerResponseHeader(StatusCodes.Status200OK, "Location", "string", "Location of the newly created resource")]
         [SwaggerResponseHeader(200, "ETag", "string", "An ETag of the resource")]
         [SwaggerResponseHeader(new int[] { 200, 401, 403, 404 }, "CustomHeader", "string", "A custom header")]
@@ -78,6 +78,45 @@ namespace WebApi.Controllers
         {
             var personResponse = new PersonResponse { Id = 1, FirstName = "Dave", LastName = "Multi" };
             return personResponse;
+        }
+
+        /// <summary>
+        /// Posts multiple types. Multiple types request body and response examples with properly generated schema
+        /// </summary>
+        /// <param name="type">Type of object to handle. Person or Animal</param>
+        /// <param name="requestObject"></param>
+        /// <response code="400">Some request input is invalid</response>
+        /// <response code="401">You are not authorized to access this endpoint</response>
+        [HttpPost]
+        [AllowAnonymous]
+        [Route("api/values/multipletypes/{type}")]
+        [SwaggerResponse(200, type: typeof(object), description: "Successfully added object")]
+        [SwaggerRequestExample(typeof(object), typeof(MultipleTypesRequestExamples))]
+        [SwaggerResponseExample(200, typeof(MultipleTypesResponseExamples))]
+        public object PostMultipleTypes([FromBody] object requestObject,
+                string type)
+        {
+            Type objectType;
+            switch (type)
+            {
+                case "Person": objectType = typeof(PersonResponse); break;
+                case "Animal": objectType = typeof(AnimalResponse); break;
+                default: return BadRequest(new ErrorResponse {ErrorCode = 400, Message = "Provided type is invalid"});
+            }
+
+            try
+            {
+                var deserialized = JsonConvert.DeserializeObject(requestObject.ToString(), objectType, new JsonSerializerSettings
+                {
+                    MissingMemberHandling = MissingMemberHandling.Error
+                });
+
+                return deserialized;
+            }
+            catch
+            {
+                return BadRequest(new ErrorResponse {ErrorCode = 400, Message = "Request body is invalid"});
+            }
         }
 
         /// <summary>

--- a/test/WebApi2.1-Swashbuckle5/Models/AnimalRequest.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/AnimalRequest.cs
@@ -1,0 +1,9 @@
+﻿namespace WebApi.Models
+{
+    public class AnimalRequest
+    {
+        public string Name { get; set; }
+        public string Race { get; set; }
+        public bool IsNeutered { get; set; }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/Models/AnimalResponse.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/AnimalResponse.cs
@@ -1,0 +1,10 @@
+﻿namespace WebApi.Models
+{
+    public class AnimalResponse
+    {
+        public int Id { get; set; }
+        public string Name { get; set; }
+        public string Race { get; set; }
+        public bool IsNeutered { get; set; }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/Models/Examples/MultipleTypesRequestExamples.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/Examples/MultipleTypesRequestExamples.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace WebApi.Models.Examples
+{
+    public class MultipleTypesRequestExamples : IMultipleExamplesProvider
+    {
+        public IEnumerable<SwaggerExample<object>> GetExamples()
+        {
+            yield return new SwaggerExample
+            {
+                Name = "Animal",
+                Summary = "Posts Animal",
+                Value = new AnimalRequest
+                {
+                    Name = "Milo",
+                    Race = "Husky",
+                    IsNeutered = true
+                }
+            };
+
+            yield return new SwaggerExample
+            {
+                Name = "Human",
+                Summary = "Posts Person",
+                Value = new PersonRequest
+                {
+                    FirstName = "Anthony",
+                    Age = 25,
+                    Title = Title.Dr,
+                    Income = 4220.58M
+                }
+            };
+        }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/Models/Examples/MultipleTypesResponseExamples.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/Examples/MultipleTypesResponseExamples.cs
@@ -1,0 +1,39 @@
+﻿using System.Collections.Generic;
+using Swashbuckle.AspNetCore.Filters;
+
+namespace WebApi.Models.Examples
+{
+    public class MultipleTypesResponseExamples : IMultipleExamplesProvider
+    {
+        public IEnumerable<SwaggerExample<object>> GetExamples()
+        {
+            yield return new SwaggerExample
+            {
+                Name = "Animal",
+                Summary = "Lovely dog",
+                Value = new AnimalResponse
+                {
+                    Id = 29,
+                    Name = "Milo",
+                    Race = "Husky",
+                    IsNeutered = true
+                }
+            };
+
+            yield return new SwaggerExample
+            {
+                Name = "Human",
+                Summary = "Humble person",
+                Value = new PersonResponse
+                {
+                    Id = 78,
+                    FirstName = "Anthony",
+                    LastName = "Brown",
+                    Age = 25,
+                    Title = Title.Dr,
+                    Income = 4220.58M,
+                }
+            };
+        }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/WebApi2.1-Swashbuckle5.csproj
+++ b/test/WebApi2.1-Swashbuckle5/WebApi2.1-Swashbuckle5.csproj
@@ -19,4 +19,10 @@
     <ProjectReference Include="..\..\src\Swashbuckle.AspNetCore.Filters\Swashbuckle.AspNetCore.Filters.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Update="Models\Examples\MultipleTypesRequestExamples.cs">
+      <Link>Models\Examples\MultipleTypesRequestExamples.cs</Link>
+    </Compile>
+  </ItemGroup>
+
 </Project>

--- a/test/WebApi3.1-Swashbuckle5/WebApi3.1-Swashbuckle5.csproj
+++ b/test/WebApi3.1-Swashbuckle5/WebApi3.1-Swashbuckle5.csproj
@@ -12,6 +12,12 @@
 
   <ItemGroup>
     <Compile Include="..\WebApi2.1-Swashbuckle5\Controllers\ValuesController.cs" Link="Controllers\ValuesController.cs" />
+    <Compile Include="..\WebApi2.1-Swashbuckle5\Models\AnimalRequest.cs">
+      <Link>Models\AnimalRequest.cs</Link>
+    </Compile>
+    <Compile Include="..\WebApi2.1-Swashbuckle5\Models\AnimalResponse.cs">
+      <Link>Models\AnimalResponse.cs</Link>
+    </Compile>
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\DynamicData.cs" Link="Models\DynamicData.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\ErrorResponse.cs" Link="Models\ErrorResponse.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\DictionaryRequestExample.cs" Link="Models\Examples\DictionaryRequestExample.cs" />
@@ -22,6 +28,12 @@
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\JsonPatchPersonRequestExample.cs" Link="Models\Examples\JsonPatchPersonRequestExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\ListPeopleRequestExample.cs" Link="Models\Examples\ListPeopleRequestExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\MaleRequestExample.cs" Link="Models\Examples\MaleRequestExample.cs" />
+    <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\MultipleTypesRequestExamples.cs">
+      <Link>Models\Examples\MultipleTypesRequestExamples.cs</Link>
+    </Compile>
+    <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\MultipleTypesResponseExamples.cs">
+      <Link>Models\Examples\MultipleTypesResponseExamples.cs</Link>
+    </Compile>
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\NotFoundResponseExample.cs" Link="Models\Examples\NotFoundResponseExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonRequestAutoExample.cs" Link="Models\Examples\PersonRequestAutoExample.cs" />
     <Compile Include="..\WebApi2.1-Swashbuckle5\Models\Examples\PersonRequestDependencyInjectionExample.cs" Link="Models\Examples\PersonRequestDependencyInjectionExample.cs" />


### PR DESCRIPTION
I wanted to use this library to provide multiple body/response examples for my co-workers, and it worked great until I wanted to make my endpoint be able take 5 different body types.

I used:
`[FromBody] object input`

As object which retrieves data from the request. Examples were shown as they should, but schema was totally empty. Now it is completly adjusted to example/examples types. You can check my new endpoint, which I've created in `WebApi3.1-Swashbuckle5`. You can even look on `HttpPatch` schema which already was in the Api, which originally points to schema unrelated to body type, and after my changes it's exactly `Operation[]`.

Additionally I found small bug in `FilterContextFor` method in tests. You were creating schemas manually and it was not working with adjusting schemas in case when nullable type was present in the test. Swagger `SchemaGenerator` reserves schemas' ids for underlying types, so I've just used concrete SchemaGenerator there, so now it will be arranged as accurate as possible.

I found one small bug by accident, which made setting multiple request examples of non-nullable Enum types as whole `SwaggerExample` object, with all properties present. I mean `Name`, `Summary` and `Value`. Now it works good.

I hope you appreciate my work and take this pull request as pointing to proper schema is also important next to the examples.