### PR TITLE
Bug recreation with suggested fixes for #209

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesOperationFilter.cs
@@ -40,7 +40,7 @@ namespace Swashbuckle.AspNetCore.Filters
             {
                 var example = serviceProvider.GetExampleWithExamplesProviderType(attr.ExamplesProviderType);
 
-                requestExample.SetRequestExampleForOperation(
+                requestExample.SetRequestBodyExampleForOperation(
                     operation,
                     context.SchemaRepository,
                     attr.RequestType,

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesOperationFilter.cs
@@ -10,7 +10,7 @@ namespace Swashbuckle.AspNetCore.Filters
     /// Adds custom Request and Response examples.
     /// You should install it using the .AddSwaggerExamples() extension method
     /// </summary>
-    internal class ExamplesOperationFilter : IOperationFilter
+    public class ExamplesOperationFilter : IOperationFilter
     {
         private readonly IServiceProvider serviceProvider;
         private readonly RequestExample requestExample;

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/MvcOutputFormatter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/MvcOutputFormatter.cs
@@ -14,7 +14,7 @@ using System.Text;
 
 namespace Swashbuckle.AspNetCore.Filters
 {
-    internal class MvcOutputFormatter
+    public class MvcOutputFormatter
     {
         private readonly object initializeLock = new object();
         private bool initializedOutputFormatterSelector;

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
@@ -23,7 +23,7 @@ namespace Swashbuckle.AspNetCore.Filters
             this.swaggerOptions = options?.Value;
         }
 
-        public void SetRequestExampleForOperation(
+        public void SetRequestBodyExampleForOperation(
             OpenApiOperation operation,
             SchemaRepository schemaRepository,
             Type requestType,
@@ -81,7 +81,7 @@ namespace Swashbuckle.AspNetCore.Filters
             var jsonExample = new Lazy<IOpenApiAny>(() => examplesConverter.SerializeExampleJson(example));
             var xmlExample = new Lazy<IOpenApiAny>(() => examplesConverter.SerializeExampleXml(example));
 
-            foreach (var content in operation.RequestBody.Content)
+            foreach (var content in operation.RequestBody.Content) //as you are explicitly setting the requestbody example, we should filter for that via the BindingSource in ServiceProviderExamplesOperationFilter
             {
                 if (content.Key.Contains("xml"))
                 {

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
@@ -10,7 +10,7 @@ using System.Linq;
 
 namespace Swashbuckle.AspNetCore.Filters
 {
-    internal class RequestExample
+    public class RequestExample
     {
         private readonly MvcOutputFormatter mvcOutputFormatter;
         private readonly SwaggerOptions swaggerOptions;
@@ -81,7 +81,7 @@ namespace Swashbuckle.AspNetCore.Filters
             var jsonExample = new Lazy<IOpenApiAny>(() => examplesConverter.SerializeExampleJson(example));
             var xmlExample = new Lazy<IOpenApiAny>(() => examplesConverter.SerializeExampleXml(example));
 
-            foreach (var content in operation.RequestBody.Content) //as you are explicitly setting the requestbody example, we should filter for that via the BindingSource in ServiceProviderExamplesOperationFilter
+            foreach (var content in operation.RequestBody.Content)
             {
                 if (content.Key.Contains("xml"))
                 {

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ResponseExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ResponseExample.cs
@@ -6,7 +6,7 @@ using System.Linq;
 
 namespace Swashbuckle.AspNetCore.Filters
 {
-    internal class ResponseExample
+    public class ResponseExample
     {
         private readonly MvcOutputFormatter mvcOutputFormatter;
 

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
@@ -43,7 +43,7 @@ namespace Swashbuckle.AspNetCore.Filters
                 }
 
                 var example = serviceProvider.GetExampleForType(parameterDescription.Type);
-                if (parameterDescription.Source == BindingSource.Body)
+                if (parameterDescription.Source == BindingSource.Body || parameterDescription.Source == BindingSource.Form || parameterDescription.Source == BindingSource.Custom)
                 {
                     requestExample.SetRequestBodyExampleForOperation(operation, context.SchemaRepository, parameterDescription.Type, example);
                 }

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
@@ -43,8 +43,6 @@ namespace Swashbuckle.AspNetCore.Filters
                 }
 
                 var example = serviceProvider.GetExampleForType(parameterDescription.Type);
-
-                //suggested fix 1
                 if (parameterDescription.Source == BindingSource.Body)
                 {
                     requestExample.SetRequestBodyExampleForOperation(operation, context.SchemaRepository, parameterDescription.Type, example);

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ServiceProviderExamplesOperationFilter.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.OpenApi.Models;
 using Swashbuckle.AspNetCore.Filters.Extensions;
 using Swashbuckle.AspNetCore.SwaggerGen;
@@ -43,7 +44,11 @@ namespace Swashbuckle.AspNetCore.Filters
 
                 var example = serviceProvider.GetExampleForType(parameterDescription.Type);
 
-                requestExample.SetRequestExampleForOperation(operation, context.SchemaRepository, parameterDescription.Type, example);
+                //suggested fix 1
+                if (parameterDescription.Source == BindingSource.Body)
+                {
+                    requestExample.SetRequestBodyExampleForOperation(operation, context.SchemaRepository, parameterDescription.Type, example);
+                }
             }
         }
 

--- a/src/Swashbuckle.AspNetCore.Filters/Extensions/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Extensions/SwaggerGenOptionsExtensions.cs
@@ -7,8 +7,10 @@ namespace Swashbuckle.AspNetCore.Filters
     {
         public static void ExampleFilters(this SwaggerGenOptions swaggerGenOptions)
         {
-            swaggerGenOptions.OperationFilter<ExamplesOperationFilter>();
+            //Suggested fix 2
             swaggerGenOptions.OperationFilter<ServiceProviderExamplesOperationFilter>();
+            swaggerGenOptions.OperationFilter<ExamplesOperationFilter>();
+
         }
     }
 }

--- a/src/Swashbuckle.AspNetCore.Filters/Extensions/SwaggerGenOptionsExtensions.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Extensions/SwaggerGenOptionsExtensions.cs
@@ -7,10 +7,14 @@ namespace Swashbuckle.AspNetCore.Filters
     {
         public static void ExampleFilters(this SwaggerGenOptions swaggerGenOptions)
         {
-            //Suggested fix 2
+            swaggerGenOptions.OperationFilter<ExamplesOperationFilter>();
+            swaggerGenOptions.OperationFilter<ServiceProviderExamplesOperationFilter>();
+        }
+
+        public static void ExampleFilters_PrioritizingExplicitlyDefinedExamples(this SwaggerGenOptions swaggerGenOptions)
+        {
             swaggerGenOptions.OperationFilter<ServiceProviderExamplesOperationFilter>();
             swaggerGenOptions.OperationFilter<ExamplesOperationFilter>();
-
         }
     }
 }

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Any;
 using Microsoft.OpenApi.Models;
@@ -154,7 +155,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
                 }
             };
             var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
-            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(PersonRequest) } };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(PersonRequest), Source = BindingSource.Body } };
             var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.PersonRequestUnannotated), parameterDescriptions);
 
             // Act
@@ -206,7 +207,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
                 }
             };
             var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
-            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(IPersonRequest) } };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(IPersonRequest), Source = BindingSource.Body } };
             var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.IPersonRequestUnannotated), parameterDescriptions);
 
             // Act
@@ -256,7 +257,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
             };
             var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
 
-            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(Title?) } };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(Title?), Source = BindingSource.Body } };
             var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.RequestTakesANullableEnum), parameterDescriptions);
 
             // Act
@@ -285,7 +286,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
                 }
             };
             var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
-            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(PersonRequest) } };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(PersonRequest), Source = BindingSource.Body } };
             var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.PersonRequestUnannotated), parameterDescriptions);
 
             // Act
@@ -340,7 +341,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
                 }
             };
             var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
-            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(PersonRequest) } };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(PersonRequest), Source = BindingSource.Body } };
             var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.PersonRequestUnannotated), parameterDescriptions);
 
             // Act
@@ -393,7 +394,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
                 }
             };
             var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
-            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(Dictionary<string, object>) } };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(Dictionary<string, object>), Source = BindingSource.Body } };
             var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.DictionaryRequestAttribute), parameterDescriptions);
 
             // Act

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterWithXmlDataContractTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterWithXmlDataContractTests.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc.ApiExplorer;
+using Microsoft.AspNetCore.Mvc.ModelBinding;
 using Microsoft.Extensions.Options;
 using Microsoft.OpenApi.Models;
 using NSubstitute;
@@ -44,7 +45,7 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
                 }
             };
             var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
-            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(Dictionary<string, object>) } };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(Dictionary<string, object>), Source = BindingSource.Body } };
             var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.DictionaryRequestAttribute), parameterDescriptions);
 
             // Act

--- a/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
+++ b/test/WebApi2.1-Swashbuckle5/Controllers/ValuesController.cs
@@ -14,10 +14,21 @@ namespace WebApi.Controllers
 {
     [Authorize]
     [Route("api/[controller]")]
+    [ApiVersion("1.0")]
     [SwaggerResponse(404, type: typeof(ErrorResponse), description: "Could not find the person")]
     [SwaggerResponseExample(404, typeof(NotFoundResponseExample))]
     public class ValuesController : Controller
     {
+        [HttpPost]
+        [Route("api/test/string/endpoint")]
+        [SwaggerResponse(StatusCodes.Status200OK, null, typeof(string))]
+        [SwaggerResponseExample(200, typeof(StringResponseExample))]
+        [SwaggerRequestExample(typeof(PersonRequest), typeof(StringRequestExample))]
+        public IActionResult StringEndpoint(string input)
+        {
+            return Ok(input);
+        }
+
         ///// <summary>
         ///// Gets a person
         ///// </summary>

--- a/test/WebApi2.1-Swashbuckle5/Models/ErrorResponse.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/ErrorResponse.cs
@@ -1,6 +1,6 @@
 ﻿namespace WebApi.Models
 {
-    internal class ErrorResponse
+    public class ErrorResponse
     {
         public int ErrorCode { get; set; }
 

--- a/test/WebApi2.1-Swashbuckle5/Models/Examples/StringRequestExample.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/Examples/StringRequestExample.cs
@@ -1,0 +1,12 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+
+namespace WebApi.Models.Examples
+{
+    internal class StringRequestExample : IExamplesProvider<string>
+    {
+        public string GetExamples()
+        {
+            return "{\"test\":\"string request example\"}";
+        }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/Models/Examples/StringResponseExample.cs
+++ b/test/WebApi2.1-Swashbuckle5/Models/Examples/StringResponseExample.cs
@@ -1,0 +1,12 @@
+﻿using Swashbuckle.AspNetCore.Filters;
+
+namespace WebApi.Models.Examples
+{
+    internal class StringResponseExample : IExamplesProvider<string>
+    {
+        public string GetExamples()
+        {
+            return "{\"test\":\"string response example\"}";
+        }
+    }
+}

--- a/test/WebApi2.1-Swashbuckle5/Program.cs
+++ b/test/WebApi2.1-Swashbuckle5/Program.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 
-namespace WebApi2._0_Swashbuckle4
+namespace WebApi2._1_Swashbuckle5
 {
     public static class Program
     {

--- a/test/WebApi2.1-Swashbuckle5/Startup.cs
+++ b/test/WebApi2.1-Swashbuckle5/Startup.cs
@@ -1,11 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Versioning;
-using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.OpenApi.Models;
@@ -29,25 +26,14 @@ namespace WebApi2._1_Swashbuckle5
         public void ConfigureServices(IServiceCollection services)
         {
             services
-                .AddMvcCore()
-                .AddApiExplorer()
-                .AddVersionedApiExplorer(options => options.GroupNameFormat = "'v'VVV")
-                .AddAuthorization()
-                .AddFormatterMappings()
-                .AddViews()
-                .AddRazorViewEngine()
-                .AddRazorPages()
-                .AddCacheTagHelper()
-                .AddDataAnnotations()
-                .AddJsonFormatters()
-                .AddCors()
+                .AddMvc()
                 .AddJsonOptions(opt =>
                 {
                     opt.SerializerSettings.Converters.Add(new StringEnumConverter());
                     // opt.SerializerSettings.NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore;
                 })
                 .AddXmlSerializerFormatters();
-            //.AddXmlDataContractSerializerFormatters();
+                //.AddXmlDataContractSerializerFormatters();
 
             services.Configure<SwaggerOptions>(c => c.SerializeAsV2 = false);
             services.AddSwaggerGen(options =>
@@ -93,7 +79,8 @@ namespace WebApi2._1_Swashbuckle5
                     authBuilder.RequireRole("Customer");
                 });
             });
-            services.AddApiVersioning(options => {
+            services.AddApiVersioning(options =>
+            {
                 options.ApiVersionReader = new HeaderApiVersionReader("api-version");
                 options.AssumeDefaultVersionWhenUnspecified = true;
                 options.ApiVersionSelector = new CurrentImplementationApiVersionSelector(options);

--- a/test/WebApi2.1-Swashbuckle5/WebApi2.1-Swashbuckle5.csproj
+++ b/test/WebApi2.1-Swashbuckle5/WebApi2.1-Swashbuckle5.csproj
@@ -11,8 +11,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.All" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="2.3.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="2.2.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.6.3" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="5.6.3" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Recreated the bug we multiple parameters colliding and overriding the request body example provided by SwaggerRequestExample.  In this case because we had a header that was of type string and one of the examples in the example repository was of type string and ServiceProviderExamplesOperationFilter is setup to run after ExamplesOperationFilter in SwaggerGenOptionsExtensions.ExampleFilters; the last parameter in the parameterDescription list with a matching IExamplesProvider clobbers any existing example that was set by ExamplesOperationFilter even if it is not of type BindingSource.Body.

Suggested fix is to check the Source parameter on the parameterDescription and only Set the RequestBody example if it matches.  It may also be prudent to make ExamplesOperationFilter run after ServiceProviderExamplesOperationFilter, that way the last example value that gets set is the one manually specified via the attributes, but I'm not sure if you specifically intended for ServiceProviderExamplesOperationFilter to run after ExamplesOperationFilter or not.

There may be a related bug in the SetResponseExamples function, but I haven't explored that.

See #209