### PR TITLE
Update readme for use with Minimal APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -546,8 +546,7 @@ in `services.AddControllers()`.
 The JsonSerializer comes from MvcOptions, but that isn't configured when using Minimial APIs.
 
 Therefore, in order to serialize as camel case, or to set another formatting options, manually configure MvcOptions in your Program.cs:
-```
-
+```csharp
 var builder = WebApplication.CreateBuilder(args);
 ...
 builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(options =>

--- a/README.md
+++ b/README.md
@@ -547,6 +547,9 @@ The JsonSerializer comes from MvcOptions, but that isn't configured when using M
 
 Therefore, in order to serialize as camel case, or to set another formatting options, manually configure MvcOptions in your Program.cs:
 ```
+
+var builder = WebApplication.CreateBuilder(args);
+...
 builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(options =>
 {
 	options.OutputFormatters.Clear();

--- a/README.md
+++ b/README.md
@@ -542,6 +542,22 @@ You can optionally specify policies `[Authorize("Customer")]` or roles `[Authori
 The above is no longer supported - it will output Examples using whichever JSON serializer your controllers are configured with
 in `services.AddControllers()`.
 
+### Minimal APIs
+As the JSON serializer refers to MvcOptions, when working with Minimial APIs camelCase is not applied (as services.AddControllers() isn't set. 
+
+In order to serialize in Camel case, or to set another formatting option configure an MvcOptions instance in your Program.cs:
+```
+builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(options =>
+{
+	options.OutputFormatters.Clear();
+	options.OutputFormatters.Add(
+		new Microsoft.AspNetCore.Mvc.Formatters.SystemTextJsonOutputFormatter(
+			new JsonSerializerOptions
+			{
+				PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+			}));
+});
+```
 
 ## Render Enums as strings
 ~~By default `enum`s will output their integer values. If you want to output strings you can pass in a `StringEnumConverter` like so:

--- a/README.md
+++ b/README.md
@@ -543,9 +543,9 @@ The above is no longer supported - it will output Examples using whichever JSON 
 in `services.AddControllers()`.
 
 ### Minimal APIs
-The JsonSerializer comes from MvcOptions, but this isn't copnfigured when using Minimial APIs. 
+The JsonSerializer comes from MvcOptions, but that isn't configured when using Minimial APIs.
 
-Therefore, in order to serialize as camel case, or to set another formatting options, configure an MvcOptions instance in your Program.cs:
+Therefore, in order to serialize as camel case, or to set another formatting options, manually configure MvcOptions in your Program.cs:
 ```
 builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(options =>
 {

--- a/README.md
+++ b/README.md
@@ -543,9 +543,9 @@ The above is no longer supported - it will output Examples using whichever JSON 
 in `services.AddControllers()`.
 
 ### Minimal APIs
-As the JSON serializer refers to MvcOptions, when working with Minimial APIs camelCase is not applied (as services.AddControllers() isn't set. 
+The JsonSerializer comes from MvcOptions, but this isn't copnfigured when using Minimial APIs. 
 
-In order to serialize in Camel case, or to set another formatting option configure an MvcOptions instance in your Program.cs:
+Therefore, in order to serialize as camel case, or to set another formatting options, configure an MvcOptions instance in your Program.cs:
 ```
 builder.Services.Configure<Microsoft.AspNetCore.Mvc.MvcOptions>(options =>
 {


### PR DESCRIPTION
The standard behaviour of json serialisation depends on the configured MvcOptions, however this doesn't work with Minimal APIs as they do not implement the Mvc pattern. 

The resultant behaviour is pascal case formatting, which often isn't desirable.

This update informs users how to configure Minimal API applications by defining the Formatter.