### PR TITLE
CSV Examples

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesConverter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ExamplesConverter.cs
@@ -29,7 +29,14 @@ namespace Swashbuckle.AspNetCore.Filters
                 return new OpenApiString(value.ToString());
             }
 
-            return new OpenApiString(mvcOutputFormatter.Serialize(value, TextCsv));
+            try
+            {
+                return new OpenApiString(mvcOutputFormatter.Serialize(value, TextCsv));
+            }
+            catch (MvcOutputFormatter.FormatterNotFoundException)
+            {
+                return new OpenApiString("No formatter found");
+            }
         }
 
         public IOpenApiAny SerializeExampleXml(object value)
@@ -46,6 +53,12 @@ namespace Swashbuckle.AspNetCore.Filters
             IEnumerable<ISwaggerExample<object>> examples)
         {
             return ToOpenApiExamplesDictionary(examples, SerializeExampleXml);
+        }
+
+        public IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionaryCsv(
+            IEnumerable<ISwaggerExample<object>> examples)
+        {
+            return ToOpenApiExamplesDictionary(examples, SerializeExampleCsv);
         }
 
         public IDictionary<string, OpenApiExample> ToOpenApiExamplesDictionaryJson(

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/RequestExample.cs
@@ -80,12 +80,17 @@ namespace Swashbuckle.AspNetCore.Filters
         {
             var jsonExample = new Lazy<IOpenApiAny>(() => examplesConverter.SerializeExampleJson(example));
             var xmlExample = new Lazy<IOpenApiAny>(() => examplesConverter.SerializeExampleXml(example));
+            var csvExample = new Lazy<IOpenApiAny>(() => examplesConverter.SerializeExampleCsv(example));
 
             foreach (var content in operation.RequestBody.Content)
             {
                 if (content.Key.Contains("xml"))
                 {
                     content.Value.Example = xmlExample.Value;
+                }
+                else if (content.Key.Contains("csv"))
+                {
+                    content.Value.Example = csvExample.Value;
                 }
                 else
                 {
@@ -113,11 +118,19 @@ namespace Swashbuckle.AspNetCore.Filters
                 examplesConverter.ToOpenApiExamplesDictionaryXml(examples)
             );
 
+            var csvExamples = new Lazy<IDictionary<string, OpenApiExample>>(() =>
+                examplesConverter.ToOpenApiExamplesDictionaryCsv(examples)
+            );
+
             foreach (var content in operation.RequestBody.Content)
             {
                 if (content.Key.Contains("xml"))
                 {
                     content.Value.Examples = xmlExamples.Value;
+                }
+                else if (content.Key.Contains("csv"))
+                {
+                    content.Value.Examples = csvExamples.Value;
                 }
                 else
                 {

--- a/src/Swashbuckle.AspNetCore.Filters/Examples/ResponseExample.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/ResponseExample.cs
@@ -86,11 +86,19 @@ namespace Swashbuckle.AspNetCore.Filters
                 examplesConverter.ToOpenApiExamplesDictionaryXml(examples)
             );
 
+            var csvExamples = new Lazy<IDictionary<string, OpenApiExample>>(() =>
+                examplesConverter.ToOpenApiExamplesDictionaryCsv(examples)
+            );
+
             foreach (var content in response.Value.Content)
             {
                 if (content.Key.Contains("xml"))
                 {
                     content.Value.Examples = xmlExamples.Value;
+                }
+                else if (content.Key.Contains("csv"))
+                {
+                    content.Value.Examples = csvExamples.Value;
                 }
                 else
                 {


### PR DESCRIPTION
This commit enables the CSV media type for response as well as request and both a single example and multiple ones.

As a CSV converter has to be manually registered a try catch block is used to catch the formatter not found exception and display a corresponding message in swagger