### PR TITLE
Fix #261 - Respect IOptions<JsonOptions> if configured

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/Examples/MvcOutputFormatter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/MvcOutputFormatter.cs
@@ -104,7 +104,16 @@ namespace Swashbuckle.AspNetCore.Filters
         {
             if (contentType.MediaType.Value.StartsWith("application/json"))
             {
-#if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER && !NET6_0_OR_GREATER
+                return System.Text.Json.JsonSerializer.Serialize(value,
+                    new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
+#elif NET6_0_OR_GREATER
+                if (serviceProvider?.GetService(typeof(IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>)) is { } jsonOptions)
+                {
+                    return System.Text.Json.JsonSerializer.Serialize(value,
+                        ((IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions>)jsonOptions).Value.SerializerOptions);
+                }
+
                 return System.Text.Json.JsonSerializer.Serialize(value,
                     new System.Text.Json.JsonSerializerOptions(System.Text.Json.JsonSerializerDefaults.Web));
 #else


### PR DESCRIPTION
I tried to make the least changes possible and arrived at that.
It should be non-breaking and I also added a unit test, all pass.

While resolving from serviceProvider does not look the prettiest, other alternative was multiple #if tags around constructor:
```c#
#if NET6_0_OR_GREATER
        private readonly Microsoft.AspNetCore.Http.Json.JsonOptions jsonOptions;
#endif

    public MvcOutputFormatter(
        IOptions<MvcOptions> options,
        IServiceProvider serviceProvider,
        ILoggerFactory loggerFactory
#if NET6_0_OR_GREATER
            IOptions<Microsoft.AspNetCore.Http.Json.JsonOptions> jsonOptions
#endif
        )
    {
        this.initializedOutputFormatterSelector = false;
        this.options = options;
        this.serviceProvider = serviceProvider;
        this.loggerFactory = loggerFactory;
#if NET6_0_OR_GREATER
            this.jsonOptions = jsonOptions.Value;
#endif
    }
```

