### PR TITLE
Fix #264 - Handle null example in IMultipleExamplesProvider<>

### DIFF
--- a/src/Swashbuckle.AspNetCore.Filters/Examples/MvcOutputFormatter.cs
+++ b/src/Swashbuckle.AspNetCore.Filters/Examples/MvcOutputFormatter.cs
@@ -66,7 +66,7 @@ namespace Swashbuckle.AspNetCore.Filters
 
             if (value == null)
             {
-                return string.Empty;
+                return "\"null\"";
             }
 
             using (var stringWriter = new StringWriter())

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Examples/ServiceProviderExamplesOperationFilterTests.cs
@@ -387,6 +387,31 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Examples
         }
 
         [Fact]
+        public void WhenMultipleRequestsExamplesReturnsNullExample_ShouldNotThrow()
+        {
+            // Arrange
+            serviceProvider.GetService(typeof(IMultipleExamplesProvider<PersonRequest>)).Returns(new PersonRequestMultipleExamplesNullExample());
+            var requestBody = new OpenApiRequestBody
+            {
+                Content = new Dictionary<string, OpenApiMediaType>
+                {
+                    { "application/json", new OpenApiMediaType() }
+                }
+            };
+            var operation = new OpenApiOperation { OperationId = "foobar", RequestBody = requestBody };
+            var parameterDescriptions = new List<ApiParameterDescription>() { new ApiParameterDescription { Type = typeof(PersonRequest), Source = BindingSource.Body } };
+            var filterContext = FilterContextFor(typeof(FakeActions), nameof(FakeActions.PersonRequestUnannotated), parameterDescriptions);
+
+            // Act
+            sut.Apply(operation, filterContext);
+
+            // Assert
+            var actualExamples = requestBody.Content["application/json"].Examples;
+            var expectedExamples = new PersonRequestMultipleExamplesNullExample().GetExamples();
+            actualExamples.ShouldAllMatch(expectedExamples, ExampleAssertExtensions.ShouldMatch);
+        }
+
+        [Fact]
         public void WhenPassingDictionary_ShouldSetExampleOnRequestSchema()
         {
             // Arrange

--- a/test/Swashbuckle.AspNetCore.Filters.Test/Extensions/ExampleAssertExtensions.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/Extensions/ExampleAssertExtensions.cs
@@ -12,6 +12,12 @@ namespace Swashbuckle.AspNetCore.Filters.Test.Extensions
     {
         public static void ShouldMatch(this PersonRequest actualExample, PersonRequest expectedExample)
         {
+            if (actualExample is null)
+            {
+                expectedExample.ShouldBeNull();
+                return;
+            }
+
             actualExample.Title.ShouldBe(expectedExample.Title);
             actualExample.FirstName.ShouldBe(expectedExample.FirstName);
             actualExample.Age.ShouldBe(expectedExample.Age);

--- a/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/PersonRequestMultipleExamples.cs
+++ b/test/Swashbuckle.AspNetCore.Filters.Test/TestFixtures/Examples/PersonRequestMultipleExamples.cs
@@ -43,6 +43,19 @@ namespace Swashbuckle.AspNetCore.Filters.Test.TestFixtures.Fakes.Examples
         }
     }
 
+    internal class PersonRequestMultipleExamplesNullExample : IMultipleExamplesProvider<PersonRequest>
+    {
+        public IEnumerable<SwaggerExample<PersonRequest>> GetExamples()
+        {
+            yield return SwaggerExample.Create("Dave",
+                "Posts Dave",
+                new PersonRequest { FirstName = "Dave", Title = Title.Mr });
+            yield return SwaggerExample.Create<PersonRequest>("Null",
+                "Posts null",
+                null);
+        }
+    }
+
     internal class PersonRequestMultipleExamplesEmpty : IMultipleExamplesProvider<PersonRequest>
     {
         public IEnumerable<SwaggerExample<PersonRequest>> GetExamples()


### PR DESCRIPTION
When providing `null` response example, `mvcOutputFormatter.Serialize()` would output `string.Empty`, `JsonNode.Parse("")` would then throw exception since its not a valid Json node.

Fixed by returning `"null"` in case of `null` example.
Returning just `null` instead of string.Empty does not work, whole example is skipped during serialization in that case.

Also added unit test for null example. (required adding null handling to `ShouldMatch` test extension method)